### PR TITLE
Replace HassanAbouelela/setup-python with ItsDrike/setup-poetry

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -26,14 +26,25 @@ jobs:
 
       - name: Regular setup python
         uses: actions/setup-python@v4
+        id: python_setup
         with:
           python-version: 3.11
+
+      - name: Python Dependency Caching
+        uses: actions/cache@v3
+        id: python_cache
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
 
       - name: Install poetry
         run: |
           pip install poetry
 
       - name: Install dependencies using poetry
+        if: steps.python_cache.outputs.cache-hit == "true"
         run: poetry install --no-root --only release
 
       - name: Add poetry environment to path

--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -45,7 +45,7 @@ jobs:
           pip install poetry
 
       - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit == "true"
+        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
         shell: bash
         run: python -m poetry install --no-root --only release
 

--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -24,7 +24,7 @@ jobs:
           # needs a non-shallow clone.
           fetch-depth: 0
 
-      - name: Regular setup python
+      - name: Setup python
         uses: actions/setup-python@v4
         id: python_setup
         with:

--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -40,12 +40,14 @@ jobs:
           key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
 
       - name: Install poetry
+        shell: bash
         run: |
           pip install poetry
 
       - name: Install dependencies using poetry
         if: steps.python_cache.outputs.cache-hit == "true"
-        run: poetry install --no-root --only release
+        shell: bash
+        run: python -m poetry install --no-root --only release
 
       - name: Add poetry environment to path
         run: |

--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -24,35 +24,12 @@ jobs:
           # needs a non-shallow clone.
           fetch-depth: 0
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        id: python_setup
+      - name: Setup poetry
+        uses: ItsDrike/setup-poetry@v1
         with:
           python-version: 3.11
-
-      - name: Python Dependency Caching
-        uses: actions/cache@v3
-        id: python_cache
-        with:
-          path: |
-            ~/.cache/pypoetry
-            ~/.cache/pip
-          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
-
-      - name: Install poetry
-        shell: bash
-        run: |
-          pip install poetry
-
-      - name: Install dependencies using poetry
-        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
-        shell: bash
-        run: python -m poetry install --no-root --only release
-
-      - name: Add poetry environment to path
-        run: |
-          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
-          python -m poetry -V
+          poetry-version: 1.3.1
+          install-args: "--no-root --only release"
 
       - name: Check if changelog fragment was added
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,11 +32,35 @@ jobs:
           git config --global user.name "py-mine-ci-bot"
           git config --global user.email "121461646+py-mine-ci-bot[bot]@users.noreply.github.com"
 
-      - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.0
+      - name: Setup python
+        uses: actions/setup-python@v4
+        id: python_setup
         with:
-          python_version: "3.11"
-          install_args: "--without lint --without test"
+          python-version: 3.11
+
+      - name: Python Dependency Caching
+        uses: actions/cache@v3
+        id: python_cache
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
+
+      - name: Install poetry
+        shell: bash
+        run: |
+          pip install poetry
+
+      - name: Install dependencies using poetry
+        if: steps.python_cache.outputs.cache-hit == "true"
+        shell: bash
+        run: python -m poetry install --no-root --only release
+
+      - name: Add poetry environment to path
+        run: |
+          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
+          python -m poetry -V
 
       - name: Checkout new branch
         run: git checkout -b "prepare-release-${{ github.event.inputs.version }}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -32,35 +32,12 @@ jobs:
           git config --global user.name "py-mine-ci-bot"
           git config --global user.email "121461646+py-mine-ci-bot[bot]@users.noreply.github.com"
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        id: python_setup
+      - name: Setup poetry
+        uses: ItsDrike/setup-poetry@v1
         with:
           python-version: 3.11
-
-      - name: Python Dependency Caching
-        uses: actions/cache@v3
-        id: python_cache
-        with:
-          path: |
-            ~/.cache/pypoetry
-            ~/.cache/pip
-          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
-
-      - name: Install poetry
-        shell: bash
-        run: |
-          pip install poetry
-
-      - name: Install dependencies using poetry
-        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
-        shell: bash
-        run: python -m poetry install --no-root --only release
-
-      - name: Add poetry environment to path
-        run: |
-          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
-          python -m poetry -V
+          poetry-version: 1.3.1
+          install-args: "--no-root --only release"
 
       - name: Checkout new branch
         run: git checkout -b "prepare-release-${{ github.event.inputs.version }}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -53,7 +53,7 @@ jobs:
           pip install poetry
 
       - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit == "true"
+        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
         shell: bash
         run: python -m poetry install --no-root --only release
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.0
+      - name: Setup python
+        uses: actions/setup-python@v4
+        id: python_setup
         with:
-          python_version: "3.11"
-          install_args: "--with release-ci"
+          python-version: 3.11
+
+      - name: Python Dependency Caching
+        uses: actions/cache@v3
+        id: python_cache
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
+
+      - name: Install poetry
+        shell: bash
+        run: |
+          pip install poetry
+
+      - name: Install dependencies using poetry
+        if: steps.python_cache.outputs.cache-hit == "true"
+        shell: bash
+        run: python -m poetry install --only release-ci
+
+      - name: Add poetry environment to path
+        run: |
+          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
+          python -m poetry -V
 
       - name: Set version with dynamic versioning
         run: poetry run poetry-dynamic-versioning

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,33 +21,12 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        id: python_setup
-
-      - name: Python Dependency Caching
-        uses: actions/cache@v3
-        id: python_cache
+      - name: Setup poetry
+        uses: ItsDrike/setup-poetry@v1
         with:
-          path: |
-            ~/.cache/pypoetry
-            ~/.cache/pip
-          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
-
-      - name: Install poetry
-        shell: bash
-        run: |
-          pip install poetry
-
-      - name: Install dependencies using poetry
-        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
-        shell: bash
-        run: python -m poetry install --only release-ci
-
-      - name: Add poetry environment to path
-        run: |
-          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
-          python -m poetry -V
+          python-version: 3.11
+          poetry-version: 1.3.1
+          install-args: "--only release-ci"
 
       - name: Set version with dynamic versioning
         run: poetry run poetry-dynamic-versioning

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
           pip install poetry
 
       - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit == "true"
+        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
         shell: bash
         run: python -m poetry install --only release-ci
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
           pip install poetry
 
       - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit == "true"
+        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
         shell: bash
         run: python -m poetry install --without lint --without release
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -27,11 +27,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup poetry
+        id: poetry_setup
         uses: ItsDrike/setup-poetry@v1
         with:
           python-version: 3.11
           poetry-version: 1.3.1
           install-args: "--without lint --without release"
+
+      - name: Pytest Cache Caching
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/.pytest_cache
+          key: "pytest-${{ runner.os }}-${{ steps.poetry_setup.outputs.python-version }}-\
+                ${{ hashFiles('./tests/**', './poetry.lock', './pyproject.toml') }}"
+          # Restore keys allows us to perform a cache restore even if the full cache key wasn't matched.
+          # That way we still end up saving new cache, but we can still make use of the cache from previous
+          # version.
+          restore-keys: "pytest-${{ runner.os }}-${{ steps.poetry_setup.outputs-python-version}}-"
 
       - name: Run pytest
         shell: bash

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,37 +26,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        id: python_setup
+      - name: Setup poetry
+        uses: ItsDrike/setup-poetry@v1
         with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Python Dependency Caching
-        uses: actions/cache@v3
-        id: python_cache
-        with:
-          path: |
-            ~/.cache/pypoetry
-            ~/.cache/pip
-          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
-
-      - name: Install poetry
-        shell: bash
-        run: |
-          pip install poetry
-
-      - name: Install dependencies using poetry
-        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
-        shell: bash
-        run: python -m poetry install --without lint --without release
-
-      - name: Add poetry environment to path
-        run: |
-          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
-          python -m poetry -V
+          python-version: 3.11
+          poetry-version: 1.3.1
+          install-args: "--without lint --without release"
 
       - name: Run pytest
+        shell: bash
         run: poetry run task test
 
   tests-done:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,11 +26,35 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.0
+      - name: Setup python
+        uses: actions/setup-python@v4
+        id: python_setup
         with:
-          python_version: "${{ matrix.python-version }}"
-          install_args: "--without lint --without release"
+          python-version: ${{ matrix.python-version }}
+
+      - name: Python Dependency Caching
+        uses: actions/cache@v3
+        id: python_cache
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
+
+      - name: Install poetry
+        shell: bash
+        run: |
+          pip install poetry
+
+      - name: Install dependencies using poetry
+        if: steps.python_cache.outputs.cache-hit == "true"
+        shell: bash
+        run: python -m poetry install --without lint --without release
+
+      - name: Add poetry environment to path
+        run: |
+          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
+          python -m poetry -V
 
       - name: Run pytest
         run: poetry run task test

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -11,6 +11,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PRE_COMMIT_HOME: "~/.cache/pre-commit"
 
 jobs:
   lint:
@@ -21,11 +23,23 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup poetry
+        id: poetry_setup
         uses: ItsDrike/setup-poetry@v1
         with:
           python-version: 3.11
           poetry-version: 1.3.1
           install-args: "--without release"
+
+      - name: Pre-commit Environment Caching
+        uses: actions/cache@v3
+        with:
+          path: ${{ env.PRE_COMMIT_HOME }}
+          key: "precommit-${{ runner.os }}-${{ steps.poetry_setup.outputs.python-version }}-\
+                ${{ hashFiles('./.pre-commit-config.yaml') }}"
+          # Restore keys allows us to perform a cache restore even if the full cache key wasn't matched.
+          # That way we still end up saving new cache, but we can still make use of the cache from previous
+          # version.
+          restore-keys: "precommit-${{ runner.os }}-${{ steps.poetry_setup.outputs-python-version}}-"
 
       - name: Run pre-commit hooks
         run: SKIP=black,isort,flake8,slotscheck,codespell,pyright pre-commit run --all-files

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
-          key: "precommit-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }-${{ hashFiles('.pre-commit-config.yaml') }}"
+          key: "precommit-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}"
 
       - name: Install poetry
         shell: bash

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -47,7 +47,7 @@ jobs:
           pip install poetry
 
       - name: Install dependencies using poetry
-        if: steps.python_cache.outputs.cache-hit == "true"
+        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
         shell: bash
         run: python -m poetry install --without release
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -20,41 +20,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Setup python
-        uses: actions/setup-python@v4
-        id: python_setup
+      - name: Setup poetry
+        uses: ItsDrike/setup-poetry@v1
         with:
           python-version: 3.11
-
-      - name: Python Dependency Caching
-        uses: actions/cache@v3
-        id: python_cache
-        with:
-          path: |
-            ~/.cache/pypoetry
-            ~/.cache/pip
-          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
-
-      - name: Pre-commit Environment Caching
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/pre-commit
-          key: "precommit-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('.pre-commit-config.yaml') }}"
-
-      - name: Install poetry
-        shell: bash
-        run: |
-          pip install poetry
-
-      - name: Install dependencies using poetry
-        if: ${{ steps.python_cache.outputs.cache-hit }} == "true"
-        shell: bash
-        run: python -m poetry install --without release
-
-      - name: Add poetry environment to path
-        run: |
-          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
-          python -m poetry -V
+          poetry-version: 1.3.1
+          install-args: "--without release"
 
       - name: Run pre-commit hooks
         run: SKIP=black,isort,flake8,slotscheck,codespell,pyright pre-commit run --all-files

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -20,11 +20,41 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install Python Dependencies
-        uses: HassanAbouelela/actions/setup-python@setup-python_v1.4.0
+      - name: Setup python
+        uses: actions/setup-python@v4
+        id: python_setup
         with:
-          python_version: "3.11"
-          install_args: "--without release"
+          python-version: 3.11
+
+      - name: Python Dependency Caching
+        uses: actions/cache@v3
+        id: python_cache
+        with:
+          path: |
+            ~/.cache/pypoetry
+            ~/.cache/pip
+          key: "python-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}"
+
+      - name: Pre-commit Environment Caching
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/pre-commit
+          key: "precommit-${{ runner.os }}-v1-${{ steps.python_setup.outputs.python-version }-${{ hashFiles('.pre-commit-config.yaml') }}"
+
+      - name: Install poetry
+        shell: bash
+        run: |
+          pip install poetry
+
+      - name: Install dependencies using poetry
+        if: steps.python_cache.outputs.cache-hit == "true"
+        shell: bash
+        run: python -m poetry install --without release
+
+      - name: Add poetry environment to path
+        run: |
+          echo "$(python -m poetry env info --path)/bin" >> $GITHUB_PATH
+          python -m poetry -V
 
       - name: Run pre-commit hooks
         run: SKIP=black,isort,flake8,slotscheck,pyright pre-commit run --all-files

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -12,7 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PRE_COMMIT_HOME: "~/.cache/pre-commit"
+  PRE_COMMIT_HOME: "/home/runner/.cache/pre-commit"
 
 jobs:
   lint:

--- a/changes/12.internal.md
+++ b/changes/12.internal.md
@@ -1,0 +1,1 @@
+Replace HassanAbouelela setup-python action with manual approach in CI workflows

--- a/changes/12.internal.md
+++ b/changes/12.internal.md
@@ -1,1 +1,1 @@
-Replace HassanAbouelela setup-python action with manual approach in CI workflows
+Replace HassanAbouelela setup-python action with ItsDrike/setup-python in CI workflows


### PR DESCRIPTION
The `HassanAbouelela/actions/setup-python` action we're currently using has several issues, which make it impractical to work with for this repository
- It needlessly performs another checkout, overriding the first one, causing issues like #8
- It doesn't cache the poetry tool itself, requiring it's installation each time (only caches the poetry environment)
- It doesn't have correctly implemented support for usage on different operating systems, making cache useless on both mac os and windows

All of these issues are addressed in [`ItsDrike/setup-poetry`](https://github.com/ItsDrike/setup-poetry), which this PR replaces the HassanAbouelela's action with.

## Tasks

- [x] Replace all HassanAboulela's setup-python actions with ItsDrike/setup-poetry
- [x] Make sure all CIs potentially running on windows explicitly use the `bash` shell in commands (currently ItsDrike/setup-poetry doesn't support using the poetry command from other shells, due to how poetry is added into $PATH)
- [x] Cache pre-commit in `validation.yml` (The HassanAboulela's action was handling this automatically, however ItsDrike/setup-poetry doesn't do that, so this caching needs to be done manually)
- [x] Cache pytest cache in `unit-test.yml`, speeding things up

## Performance analysis

When (all) caches are hit, the HassanAbouelela's action takes on average ~16 seconds, while the new action only takes ~7 seconds. This is due to the new action also caching the poetry installation itself, on top of just the poetry environment with the dependencies.

When no caches are hit, the installation time seems to very greatly, these are the observed values for HassanAbouelela's action: 1 minute, 29 seconds, 40 seconds, 1 minute and 48 seconds, 1 minute and 37 seconds. Whereas with the new action (though the data here are limited as there weren't that many runs of this action yet, and especially not those which don't hit any cache), these are the observed times: 37 seconds, 20 seconds, 20 seconds, 40 seconds, 32 seconds.

In both cases, there is a clear and significant speed improvement. 

On top of that, the new action uses 2 distinct caches, one for the poetry tool itself, and the other for the poetry environments alone (containing the project's dependencies). This means that unless the poetry or python versions are changed, this cache will always be hit, making poetry installation hit the cache almost every time.

The poetry environment caching also uses restore keys and supports partial matches, which means that even when there isn't a full match on the environment cache key (most likely due to a change in poetry.lock or pyproject.toml), some cache will still be restored from a partial match (on same operating system, python version and poetry version), which means that the dependency installation will already be working from a fully created environment, and installation of many packages will therefore be skipped, due to these already being in the restored cache.

Additionally, the HassanAbouelela's action doesn't properly handle caching on windows systems, leading to windows CI often taking up a lot more time. Since this new action handles the windows case properly, we end up hitting the cache on windows quite often, as opposed to never with the original action.

## Caveats

While it's clear that switching to ItsDrike/setup-poetry action has massive performance benefits, there are some downsides to switching too. Most notably, this is the downside of this new action containing some potential bugs. This is due to this action still being very new, as it was only created recently, and so there simply weren't that many runs of it anywhere outside of some testing environments, which might not have tested for everything. This is especially the case due to it's windows support, as windows in CIs is generally buggy and hard to deal with, making the potential for encountering bugs quite a lot bigger.

However, the action is being actively maintained and any bugs can simply be reported and should end up getting fixed relatively quickly, so while there is a big potential that some bugs will come up, it shouldn't be a huge issue, and from the few runs that occurred in this PR, and some additional testing of the action that I did, it seems to be working properly.

Another disadvantage that this action introduces is the lack of support for using the `poetry` command from cmd/powershell, due to an issue with how it's added into the `$PATH`, forcing us to use the bash shell for every command that requires poetry. 

This however isn't a huge issue, as we pretty much already are using the bash shell everywhere, and this issue is a known bug and it's expected to get fixed eventually.