### PR TITLE
Use sphinx rst format in all docstrings

### DIFF
--- a/changes/18.docs.md
+++ b/changes/18.docs.md
@@ -1,0 +1,1 @@
+Rewrite all docstrings into proper Sphinx format, instead of using markdown.

--- a/mcproto/buffer.py
+++ b/mcproto/buffer.py
@@ -13,18 +13,26 @@ class Buffer(BaseSyncWriter, BaseSyncReader, bytearray):
         self.pos = 0
 
     def write(self, data: bytes) -> None:
-        """Write new data into the buffer."""
+        """Write/Store given ``data`` into the buffer."""
         self.extend(data)
 
     def read(self, length: int) -> bytearray:
         """Read data stored in the buffer.
 
         Reading data doesn't remove that data, rather that data is treated as already read, and
-        next read will start from the first unread byte. If freeing the data is necessary, check the clear function.
+        next read will start from the first unread byte. If freeing the data is necessary, check
+        the :meth:`.clear` function.
 
-        Trying to read more data than is available will raise an IOError, however it will deplete the remaining data
-        and the partial data that was read will be a part of the error message. This behavior is here to mimic reading
-        from a socket connection.
+        :param length:
+            Amount of bytes to be read.
+
+            If the requested amount can't be read (buffer doesn't contain that much data/buffer
+            doesn't contain any data), an :exc:`IOError` will be reaised.
+
+            If there were some data in the buffer, but it was less than requested, this remaining
+            data will still be depleted and the partial data that was read will be a part of the
+            error message in the :exc:`IOError`. This behavior is here to mimic reading from a real
+            socket connection.
         """
         end = self.pos + length
 
@@ -43,11 +51,16 @@ class Buffer(BaseSyncWriter, BaseSyncReader, bytearray):
             self.pos = end
 
     def clear(self, only_already_read: bool = False) -> None:
-        """
-        Clear out the stored data and reset position.
+        """Clear out the stored data and reset position.
 
-        If `only_already_read` is True, only clear out the data which was already read, and reset the position.
-        This is mostly useful to avoid keeping large chunks of data in memory for no reason.
+        :param only_already_read:
+            When set to ``True``, only the data that was already marked as read will be cleared,
+            and the position will be reset (to start at the remaining data). This can be useful
+            for avoiding needlessly storing large amounts of data in memory, if this data is no
+            longer useful.
+
+            Otherwise, if set to ``False``, all of the data is cleared, and the position is reset,
+            essentially resulting in a blank buffer.
         """
         if only_already_read:
             del self[: self.pos]
@@ -56,7 +69,11 @@ class Buffer(BaseSyncWriter, BaseSyncReader, bytearray):
         self.pos = 0
 
     def reset(self) -> None:
-        """Reset the position in the buffer."""
+        """Reset the position in the buffer.
+
+        Since the buffer doesn't automatically clear the already read data, it is possible to simply
+        reset the position and read the data it contains again.
+        """
         self.pos = 0
 
     def flush(self) -> bytearray:
@@ -67,5 +84,5 @@ class Buffer(BaseSyncWriter, BaseSyncReader, bytearray):
 
     @property
     def remaining(self) -> int:
-        """Get the amount of bytes that's still remaining in be buffer to be read."""
+        """Get the amount of bytes that's still remaining in the buffer to be read."""
         return len(self) - self.pos

--- a/mcproto/packets/interactions.py
+++ b/mcproto/packets/interactions.py
@@ -66,13 +66,13 @@ def _deserialize_packet(
 
 
 def sync_write_packet(writer: BaseSyncWriter, packet: Packet, *, compressed: bool = False) -> None:
-    """Write given packet."""
+    """Write given ``packet``."""
     data_buf = _serialize_packet(packet, compressed=compressed)
     writer.write_bytearray(data_buf)
 
 
 async def async_write_packet(writer: BaseAsyncWriter, packet: Packet, *, compressed: bool = False) -> None:
-    """Write given packet."""
+    """Write given ``packet``."""
     data_buf = _serialize_packet(packet, compressed=compressed)
     await writer.write_bytearray(data_buf)
 

--- a/mcproto/packets/map.py
+++ b/mcproto/packets/map.py
@@ -57,16 +57,18 @@ class PacketMap(VersionMap["tuple[PacketDirection, GameState, int]", "type[Packe
     ) -> TypeGuard[type[Packet]]:
         """Determine whether a member object should be considered as a valid component for given protocol version.
 
-        This method will be called for each potential member object (found when walking over all members of
-        __all__ from all submodules of the package for given protocol version).
+        When versioned components are obtained, all of the members listed in any module's ``__all__`` are
+        considered. This function serves as a filter, identifying whether a potential member object should be
+        considered as one of the versioned components.
 
-        This function shouldn't include any checks on whether an object is already registered in the version map
-        (key collisions), these are handled during the collection in load_version, all this function is responsible
-        for is checking whether this object is a valid component, components with conflicting keys are still
-        considered valid here, as they're handled elsewhere.
+        .. note:
+            This function shouldn't include any checks on whether an object is already registered in the version
+            map (key collisions), these are handled during the collection in :meth:`.load_version`, all this
+            function is responsible for is checking whether this object is a valid component, components with
+            conflicting keys are still considered valid here, as they're handled elsewhere.
 
-        Although if there is some additional data that needs to be unique for a component to be valid, which wouldn't
-        be caught as a key collision, this function can raise a ValueError.
+            However if there is some additional data that needs to be unique for a component to be valid, which
+            wouldn't be caught as a key collision, this function can raise a :exc:`ValueError`.
         """
         return issubclass(obj, Packet)
 
@@ -77,12 +79,13 @@ class PacketMap(VersionMap["tuple[PacketDirection, GameState, int]", "type[Packe
         module_data: WalkableModuleData,
         protocol_version: int,
     ) -> tuple[PacketDirection, GameState, int]:
-        """Construct a unique obtain key for given object under given protocol version.
+        """Construct a unique obtain key for given versioned component (``obj``) under given ``protocol_version``.
 
-        Note: While the protocol version might be beneficial to know when constructing
-        the obtain key, it shouldn't be used directly as a part of the key, as the items
-        will already be split by their protocol versions, and this version will be known
-        at obtaining time.
+        .. note:
+            While the protocol version might be beneficial to know when constructing
+            the obtain key, it shouldn't be used directly as a part of the key, as the items
+            will already be split by their protocol versions, and this version will be known
+            at obtaining time.
         """
         if issubclass(obj, ClientBoundPacket):
             direction = PacketDirection.CLIENTBOUND

--- a/mcproto/packets/v757/handshaking/handshake.py
+++ b/mcproto/packets/v757/handshaking/handshake.py
@@ -21,13 +21,7 @@ class NextState(IntEnum):
 
 
 class Handshake(ServerBoundPacket):
-    """Initializes connection between server and client. (Client -> Server)
-
-    :param int protocol_version: Protocol version number to be used.
-    :param str server_address: The host/address the client is connecting to.
-    :param int server_port: The port the client is connecting to.
-    :param Union[NextState, int] next_state: The next state for the server to move into.
-    """
+    """Initializes connection between server and client. (Client -> Server)"""
 
     PACKET_ID: ClassVar[int] = 0x00
     GAME_STATE: ClassVar[GameState] = GameState.HANDSHAKING
@@ -42,6 +36,12 @@ class Handshake(ServerBoundPacket):
         server_port: int,
         next_state: Union[NextState, int],
     ):
+        """
+        :param protocol_version: Protocol version number to be used.
+        :param server_address: The host/address the client is connecting to.
+        :param server_port: The port the client is connecting to.
+        :param next_state: The next state for the server to move into.
+        """
         if isinstance(next_state, int):
             rev_lookup = {x.value: x for x in NextState.__members__.values()}
             try:

--- a/mcproto/packets/v757/status/ping.py
+++ b/mcproto/packets/v757/status/ping.py
@@ -12,10 +12,7 @@ __all__ = ["PingPong"]
 
 
 class PingPong(ClientBoundPacket, ServerBoundPacket):
-    """Ping request/Pong response (Server <-> Client).
-
-    :param int payload: Random number to test out the connection (ideally a long one).
-    """
+    """Ping request/Pong response (Server <-> Client)."""
 
     __slots__ = ("payload",)
 
@@ -23,6 +20,11 @@ class PingPong(ClientBoundPacket, ServerBoundPacket):
     GAME_STATE: ClassVar[GameState] = GameState.STATUS
 
     def __init__(self, payload: int):
+        """
+        :param payload:
+            Random number to test out the connection. Ideally, this number should be quite big,
+            however it does need to fit within the limit of a signed long long (-2 ** 63 to 2 ** 63 - 1).
+        """
         self.payload = payload
 
     def serialize(self) -> Buffer:

--- a/mcproto/packets/v757/status/status.py
+++ b/mcproto/packets/v757/status/status.py
@@ -28,10 +28,7 @@ class StatusRequest(ServerBoundPacket):
 
 
 class StatusResponse(ClientBoundPacket):
-    """Response from the server to requesting client with status data information. (Server -> Client)
-
-    :param dict[str, Any] data: JSON response data sent back to the client.
-    """
+    """Response from the server to requesting client with status data information. (Server -> Client)"""
 
     __slots__ = ("data",)
 
@@ -39,6 +36,9 @@ class StatusResponse(ClientBoundPacket):
     GAME_STATE: ClassVar[GameState] = GameState.STATUS
 
     def __init__(self, data: dict[str, Any]):
+        """
+        :param data: JSON response data sent back to the client.
+        """
         self.data = data
 
     def serialize(self) -> Buffer:

--- a/mcproto/protocol/base_io.py
+++ b/mcproto/protocol/base_io.py
@@ -29,7 +29,11 @@ R = TypeVar("R")
 
 
 class StructFormat(str, Enum):
-    """All possible write/read struct types."""
+    """All possible write/read struct types.
+
+    .. seealso:
+        :module:`struct` module documentation.
+    """
 
     BOOL = "?"
     CHAR = "c"
@@ -98,7 +102,7 @@ class BaseAsyncWriter(ABC):
         ...
 
     async def write_value(self, fmt: StructFormat, value: object, /) -> None:
-        """Write a value of given struct format in big-endian mode."""
+        """Write a given ``value`` as given struct format (``fmt``) in big-endian mode."""
         await self.write(struct.pack(">" + fmt.value, value))
 
     async def _write_varuint(self, value: int, /, *, max_bits: Optional[int] = None) -> None:
@@ -106,9 +110,9 @@ class BaseAsyncWriter(ABC):
 
         This is a standard way of transmitting ints, and it allows smaller numbers to take less bytes.
 
-        Writing will be limited up to integer values of `max_bits` bits, and trying to write bigger values will rase a
-        ValueError. Note that setting `max_bits` to for example 32 bits doesn't mean that at most 4 bytes will be sent,
-        in this case it would actually take at most 5 bytes, due to the variable encoding overhead.
+        Writing will be limited up to integer values of ``max_bits`` bits, and trying to write bigger values will rase
+        a :exc:`ValueError`. Note that setting ``max_bits`` to for example 32 bits doesn't mean that at most 4 bytes
+        will be sent, in this case it would actually take at most 5 bytes, due to the variable encoding overhead.
 
         Varints send bytes where 7 least significant bits are value bits, and the most significant bit is continuation
         flag bit. If this continuation bit is set (1), it indicates that there will be another varint byte sent after
@@ -132,7 +136,7 @@ class BaseAsyncWriter(ABC):
     async def write_varint(self, value: int, /) -> None:
         """Write a 32-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_write_varuint` docstring.
+        For more information about variable length format check :meth:`._write_varuint`.
         """
         val = to_twos_complement(value, bits=32)
         await self._write_varuint(val, max_bits=32)
@@ -140,7 +144,7 @@ class BaseAsyncWriter(ABC):
     async def write_varlong(self, value: int, /) -> None:
         """Write a 64-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_write_varuint` docstring.
+        For more information about variable length format check :meth:`._write_varuint`.
         """
         val = to_twos_complement(value, bits=64)
         await self._write_varuint(val, max_bits=64)
@@ -163,10 +167,10 @@ class BaseAsyncWriter(ABC):
 
         Individual UTF-8 characters can take up to 4 bytes, however most of the common ones take up less. Assuming the
         worst case of 4 bytes per every character, at most 131068 data bytes will be written + 3 additional bytes from
-        the varint encoding overhead. Note that the limit of 32767 characters holds, even if we're writing shorter
-        characters, and we wouldn't cross the 131068 bytes data limit.
+        the varint encoding overhead.
 
-        If the given string is longer than this, ValueError will be raised.
+        :raises ValueError:
+            If the given string ``value`` has more characters than the allowed maximum (32767).
         """
         if len(value) > 32767:
             raise ValueError("Maximum character limit for writing strings is 32767 characters.")
@@ -176,13 +180,11 @@ class BaseAsyncWriter(ABC):
         await self.write(data)
 
     async def write_optional(self, value: Optional[T], /, writer: Callable[[T], Awaitable[R]]) -> Optional[R]:
-        """Writes bool determining is value is present, if it is, also writes the value with writer function.
+        """Writes a bool showing if a ``value`` is present, if so, also writes this value with ``writer`` function.
 
-        When the `value` is None, a bool of False will be written and function will end. Otherwise, if `value` isn't
-        None, True will be written, followed by calling the `writer` function wchich will be passed the `value` as the
-        only argument. This function is expected to properly write the value into this buffer/connection.
-
-        Will return None if the `value` was None, or the value returned by the `writer` function.
+        * When ``value`` is ``None``, a bool of ``False`` will be written, and ``None`` is returned.
+        * When ``value`` is not ``None``, a bool of ``True`` is written, after which the ``writer`` function is called,
+          and the return value is forwarded.
         """
         if value is None:
             await self.write_value(StructFormat.BOOL, False)
@@ -218,7 +220,7 @@ class BaseSyncWriter(ABC):
         ...
 
     def write_value(self, fmt: StructFormat, value: object, /) -> None:
-        """Write a value of given struct format in big-endian mode."""
+        """Write a given ``value`` as given struct format (``fmt``) in big-endian mode."""
         self.write(struct.pack(">" + fmt.value, value))
 
     def _write_varuint(self, value: int, /, *, max_bits: Optional[int] = None) -> None:
@@ -226,9 +228,9 @@ class BaseSyncWriter(ABC):
 
         This is a standard way of transmitting ints, and it allows smaller numbers to take less bytes.
 
-        Writing will be limited up to integer values of `max_bits` bits, and trying to write bigger values will rase a
-        ValueError. Note that setting `max_bits` to for example 32 bits doesn't mean that at most 4 bytes will be sent,
-        in this case it would actually take at most 5 bytes, due to the variable encoding overhead.
+        Writing will be limited up to integer values of ``max_bits`` bits, and trying to write bigger values will rase
+        a :exc:`ValueError`. Note that setting ``max_bits`` to for example 32 bits doesn't mean that at most 4 bytes
+        will be sent, in this case it would actually take at most 5 bytes, due to the variable encoding overhead.
 
         Varints send bytes where 7 least significant bits are value bits, and the most significant bit is continuation
         flag bit. If this continuation bit is set (1), it indicates that there will be another varint byte sent after
@@ -252,7 +254,7 @@ class BaseSyncWriter(ABC):
     def write_varint(self, value: int, /) -> None:
         """Write a 32-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_write_varuint` docstring.
+        For more information about variable length format check :meth:`._write_varuint`.
         """
         val = to_twos_complement(value, bits=32)
         self._write_varuint(val, max_bits=32)
@@ -260,7 +262,7 @@ class BaseSyncWriter(ABC):
     def write_varlong(self, value: int, /) -> None:
         """Write a 64-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_write_varuint` docstring.
+        For more information about variable length format check :meth:`._write_varuint` docstring.
         """
         val = to_twos_complement(value, bits=64)
         self._write_varuint(val, max_bits=64)
@@ -283,10 +285,10 @@ class BaseSyncWriter(ABC):
 
         Individual UTF-8 characters can take up to 4 bytes, however most of the common ones take up less. Assuming the
         worst case of 4 bytes per every character, at most 131068 data bytes will be written + 3 additional bytes from
-        the varint encoding overhead. Note that the limit of 32767 characters holds, even if we're writing shorter
-        characters, and we wouldn't cross the 131068 bytes data limit.
+        the varint encoding overhead.
 
-        If the given string is longer than this, ValueError will be raised.
+        :raises ValueError:
+            If the given string ``value`` has more characters than the allowed maximum (32767).
         """
         if len(value) > 32767:
             raise ValueError("Maximum character limit for writing strings is 32767 characters.")
@@ -296,13 +298,11 @@ class BaseSyncWriter(ABC):
         self.write(data)
 
     def write_optional(self, value: Optional[T], /, writer: Callable[[T], R]) -> Optional[R]:
-        """Writes bool determining is value is present, if it is, also writes the value with writer function.
+        """Writes a bool showing if a ``value`` is present, if so, also writes this value with ``writer`` function.
 
-        When the `value` is None, a bool of False will be written and function will end. Otherwise, if `value` isn't
-        None, True will be written, followed by calling the `writer` function wchich will be passed the `value` as the
-        only argument. This function is expected to properly write the value into this buffer/connection.
-
-        Will return None if the `value` was None, or the value returned by the `writer` function.
+        * When ``value`` is ``None``, a bool of ``False`` will be written, and ``None`` is returned.
+        * When ``value`` is not ``None``, a bool of ``True`` is written, after which the ``writer`` function is called,
+          and the return value is forwarded.
         """
         if value is None:
             self.write_value(StructFormat.BOOL, False)
@@ -342,7 +342,7 @@ class BaseAsyncReader(ABC):
         ...
 
     async def read_value(self, fmt: StructFormat, /) -> object:
-        """Read a value into given struct format in big-endian mode.
+        """Read a value as given struct format (``fmt``) in big-endian mode.
 
         The amount of bytes to read will be determined based on the struct format automatically.
         """
@@ -356,9 +356,9 @@ class BaseAsyncReader(ABC):
 
         This is a standard way of transmitting ints, and it allows smaller numbers to take less bytes.
 
-        Reading will be limited up to integer values of `max_bits` bits, and trying to read bigger values will rase an
-        IOError. Note that setting `max_bits` to for example 32 bits doesn't mean that at most 4 bytes will be read,
-        in this case it would actually read at most 5 bytes, due to the variable encoding overhead.
+        Reading will be limited up to integer values of ``max_bits`` bits, and trying to read bigger values will rase
+        an :exc:`IOError`. Note that setting ``max_bits`` to for example 32 bits doesn't mean that at most 4 bytes
+        will be read, in this case we would actually read at most 5 bytes, due to the variable encoding overhead.
 
         Varints send bytes where 7 least significant bits are value bits, and the most significant bit is continuation
         flag bit. If this continuation bit is set (1), it indicates that there will be another varint byte sent after
@@ -388,7 +388,7 @@ class BaseAsyncReader(ABC):
     async def read_varint(self) -> int:
         """Read a 32-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_read_varuint` docstring.
+        For more information about variable length format check :meth:`._read_varuint`.
         """
         unsigned_num = await self._read_varuint(max_bits=32)
         val = from_twos_complement(unsigned_num, bits=32)
@@ -397,7 +397,7 @@ class BaseAsyncReader(ABC):
     async def read_varlong(self) -> int:
         """Read a 64-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_read_varuint` docstring.
+        For more information about variable length format check :meth:`._read_varuint`.
         """
         unsigned_num = await self._read_varuint(max_bits=64)
         val = from_twos_complement(unsigned_num, bits=64)
@@ -424,10 +424,15 @@ class BaseAsyncReader(ABC):
 
         Individual UTF-8 characters can take up to 4 bytes, however most of the common ones take up less. Assuming the
         worst case of 4 bytes per every character, at most 131068 data bytes will be read + 3 additional bytes from
-        the varint encoding overhead. Note that the while the limit of 32767 characters is enforced, this check only
-        happens after the data was already read.
+        the varint encoding overhead.
 
-        If the given string is longer than this, IOError will be raised.
+        :raises IOError:
+            * If the prefix varint is bigger than the maximum (131068) bytes, the string will not be read at all,
+              and :exc:`IOError` will be raised immediately.
+            * If the received string has more than the maximum amount of characters (32767). Note that in this case,
+              the string will still get read in it's entirety, since it fits into the maximum bytes limit (131068),
+              which was simply read at once. This limitation is here only to replicate the behavior of minecraft's
+              implementation.
         """
         length = await self.read_varint()
         if length > 131068:
@@ -442,12 +447,10 @@ class BaseAsyncReader(ABC):
         return chars
 
     async def read_optional(self, reader: Callable[[], Awaitable[R]]) -> Optional[R]:
-        """Reads bool determining is value is present, if it is, also reads the value with reader function.
+        """Reads a bool showing if a value is present, if so, also reads this value with ``reader`` function.
 
-        When False is read, the function will not read anything and end. Otherwise, if True is read, the `reader`
-        function will be called, which is expected to properly read the value from this buffer/connection.
-
-        Will return None if the False was encountered, or the value returned by the `reader` function.
+        * When ``False`` is read, the function will not read anything and ``None`` is returned.
+        * When ``True`` is read, the ``reader`` function is called, and it's return value is forwarded.
         """
         if not await self.read_value(StructFormat.BOOL):
             return None
@@ -495,9 +498,9 @@ class BaseSyncReader(ABC):
 
         This is a standard way of transmitting ints, and it allows smaller numbers to take less bytes.
 
-        Reading will be limited up to integer values of `max_bits` bits, and trying to read bigger values will rase an
-        IOError. Note that setting `max_bits` to for example 32 bits doesn't mean that at most 4 bytes will be read,
-        in this case it would actually read at most 5 bytes, due to the variable encoding overhead.
+        Reading will be limited up to integer values of ``max_bits`` bits, and trying to read bigger values will rase
+        an :exc:`IOError`. Note that setting ``max_bits`` to for example 32 bits doesn't mean that at most 4 bytes
+        will be read, in this case we would actually read at most 5 bytes, due to the variable encoding overhead.
 
         Varints send bytes where 7 least significant bits are value bits, and the most significant bit is continuation
         flag bit. If this continuation bit is set (1), it indicates that there will be another varint byte sent after
@@ -527,7 +530,7 @@ class BaseSyncReader(ABC):
     def read_varint(self) -> int:
         """Read a 32-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_read_varuint` docstring.
+        For more information about variable length format check :meth:`._read_varuint`.
         """
         unsigned_num = self._read_varuint(max_bits=32)
         val = from_twos_complement(unsigned_num, bits=32)
@@ -536,7 +539,7 @@ class BaseSyncReader(ABC):
     def read_varlong(self) -> int:
         """Read a 64-bit signed integer in a variable length format.
 
-        For more information about variable length format check `_read_varuint` docstring.
+        For more information about variable length format check :meth:`._read_varuint`.
         """
         unsigned_num = self._read_varuint(max_bits=64)
         val = from_twos_complement(unsigned_num, bits=64)
@@ -563,10 +566,15 @@ class BaseSyncReader(ABC):
 
         Individual UTF-8 characters can take up to 4 bytes, however most of the common ones take up less. Assuming the
         worst case of 4 bytes per every character, at most 131068 data bytes will be read + 3 additional bytes from
-        the varint encoding overhead. Note that the while the limit of 32767 characters is enforced, this check only
-        happens after the data was already read.
+        the varint encoding overhead.
 
-        If the given string is longer than this, IOError will be raised.
+        :raises IOError:
+            * If the prefix varint is bigger than the maximum (131068) bytes, the string will not be read at all,
+              and :exc:`IOError` will be raised immediately.
+            * If the received string has more than the maximum amount of characters (32767). Note that in this case,
+              the string will still get read in it's entirety, since it fits into the maximum bytes limit (131068),
+              which was simply read at once. This limitation is here only to replicate the behavior of minecraft's
+              implementation.
         """
         length = self.read_varint()
         if length > 131068:
@@ -581,12 +589,10 @@ class BaseSyncReader(ABC):
         return chars
 
     def read_optional(self, reader: Callable[[], R]) -> Optional[R]:
-        """Reads bool determining is value is present, if it is, also reads the value with reader function.
+        """Reads a bool showing if a value is present, if so, also reads this value with ``reader`` function.
 
-        When False is read, the function will not read anything and end. Otherwise, if True is read, the `reader`
-        function will be called, which is expected to properly read the value from this buffer/connection.
-
-        Will return None if the False was encountered, or the value returned by the `reader` function.
+        * When ``False`` is read, the function will not read anything and ``None`` is returned.
+        * When ``True`` is read, the ``reader`` function is called, and it's return value is forwarded.
         """
         if not self.read_value(StructFormat.BOOL):
             return None

--- a/mcproto/protocol/utils.py
+++ b/mcproto/protocol/utils.py
@@ -3,25 +3,35 @@ from __future__ import annotations
 __all__ = ["to_twos_complement", "from_twos_complement"]
 
 
-def to_twos_complement(num: int, bits: int) -> int:
-    """Convert a given number into twos complement format of given amount of bits."""
+def to_twos_complement(number: int, bits: int) -> int:
+    """Convert a given ``number`` into twos complement format of given amount of ``bits``.
+
+    :raises ValueError:
+        Given ``number`` is out of range, and can't be converted into twos complement format, since
+        it wouldn't fit into the given amount of ``bits``.
+    """
     value_max = 1 << (bits - 1)
     value_min = value_max * -1
     # With two's complement, we have one more negative number than positive
     # this means we can't be exactly at value_max, but we can be at exactly value_min
-    if num >= value_max or num < value_min:
-        raise ValueError(f"Can't convert number {num} into {bits}-bit twos complement format - out of range")
+    if number >= value_max or number < value_min:
+        raise ValueError(f"Can't convert number {number} into {bits}-bit twos complement format - out of range")
 
-    return num + (1 << bits) if num < 0 else num
+    return number + (1 << bits) if number < 0 else number
 
 
-def from_twos_complement(num: int, bits: int) -> int:
-    """Convert a given number from twos complement format of given amount of bits."""
+def from_twos_complement(number: int, bits: int) -> int:
+    """Convert a given ``number`` from twos complement format of given amount of ``bits``.
+
+    :raises ValueError:
+        Given ``number`` doesn't fit into given amount of ``bits``. This likely means that you're using
+        the wrong number, or that the number was converted into twos complement with higher amount of ``bits``.
+    """
     value_max = (1 << bits) - 1
-    if num < 0 or num > value_max:
-        raise ValueError(f"Can't convert number {num} from {bits}-bit twos complement format - out of range")
+    if number < 0 or number > value_max:
+        raise ValueError(f"Can't convert number {number} from {bits}-bit twos complement format - out of range")
 
-    if num & (1 << (bits - 1)) != 0:
-        num -= 1 << bits
+    if number & (1 << (bits - 1)) != 0:
+        number -= 1 << bits
 
-    return num
+    return number

--- a/mcproto/utils/abc.py
+++ b/mcproto/utils/abc.py
@@ -14,21 +14,22 @@ __all__ = ["RequiredParamsABCMixin", "Serializable"]
 class RequiredParamsABCMixin:
     """Mixin class to ABCs that require certain attributes to be set in order to allow initialization.
 
-    This class performs a similar check to what ABCs already do for abstractmethods, but for class
-    variables. The required class variable names are set with _REQUIRED_CLASS_VARS class variable,
-    which itself is automatically required.
+    This class performs a similar check to what :class:`~abc.ABC` already des with abstractmethods,
+    but for class variables. The required class variable names are set with :attr:`._REQUIRED_CLASS_VARS`
+    class variable, which itself is automatically required.
 
     Just like with ABCs, this doesn't prevent creation of classes without these required class vars
-    missing, only initialization is prevented. This is done to allow creation of a more specific, but
+    defined, only initialization is prevented. This is done to allow creation of a more specific, but
     still abstract class.
 
-    Additionally, you can also define _REQUIRED_CLASS_VARS_NO_MRO class var, holding names of class vars
-    which should be defined on given class directly. That means inheritance will be ignored so even if a
-    subclass defines the required class var, unless the latest class also defines it, this check will fail.
+    Additionally, you can also define :attr:`._REQUIRED_CLASS_VARS_NO_MRO` class var, holding names of
+    class vars which should be defined on given class directly. That means inheritance will be ignored
+    so even if a subclass defines the required class var, unless the latest class also defines it, this
+    check will fail.
 
-    This is often useful for classes that are expected to be slotted, as each subclass need to define
-    __slots__, otherwise a __dict__ will automatically be made for it. However this is entirely optional,
-    and if _REQUIRED_CLASS_VARS_NO_MRO isn't set, no such check will be performed.
+    This is often useful for classes that are expected to be slotted, as each subclass will need to define
+    ``__slots__``, otherwise a ``__dict__`` will automatically be made for it. However this is entirely
+    optional, and if :attr:`._REQUIRED_CLASS_VARS_NO_MRO` isn't set, this check is skipped.
     """
 
     __slots__ = ()
@@ -63,17 +64,17 @@ class RequiredParamsABCMixin:
 
 
 class Serializable(ABC):
-    """Base class for any type that should be (de)serializable into/from given buffer data."""
+    """Base class for any type that should be (de)serializable into/from :class:`~mcproto.Buffer` data."""
 
     __slots__ = ()
 
     @abstractmethod
     def serialize(self) -> Buffer:
-        """Represent the object as a transmittable sequence of bytes."""
+        """Represent the object as a :class:`~mcproto.Buffer` (transmittable sequence of bytes)."""
         raise NotImplementedError
 
     @classmethod
     @abstractmethod
     def deserialize(cls, buf: Buffer, /) -> Self:
-        """Construct the object from it's received byte representation."""
+        """Construct the object from a :class:`~mcproto.Buffer` (transmitable sequence of bytes)."""
         raise NotImplementedError

--- a/mcproto/utils/deprecation.py
+++ b/mcproto/utils/deprecation.py
@@ -27,10 +27,17 @@ def deprecation_warn(
     """Produce an appropriate deprecation warning given the parameters.
 
     If the currently installed project version is already past the specified deprecation version,
-    a DeprecationWarning will be raised as a full exception. Otherwise it will just get emitted
+    a :exc:`DeprecationWarning` will be raised as a full exception. Otherwise it will just get emitted
     as a warning.
 
     The deprecation message used will be constructed based on the input parameters.
+
+    :param obj_name: Name of the object that got deprecated (such as ``my_function``).
+    :param removal_version:
+        Version at which this object should be considered as deprecated and should no longer be used.
+    :param replacement: A new alternative to this (now deprecated) object.
+    :param extra_msg: Additional message included in the deprecation warning/exception at the end.
+    :param stack_level: Stack level at which the warning is emitted.
     """
     if isinstance(removal_version, str):
         removal_version = SemanticVersion.from_string(removal_version)
@@ -77,10 +84,24 @@ def deprecated(
 ) -> DecoratorFunction:
     """Mark an object as deprecated.
 
-    Decorator version of ``deprecation_warn`` function.
+    Decorator version of :func:`.deprecation_warn` function.
 
-    By default, the display name will be obtained from the decorated object (__qualname__), if this is not
-    desired, you can specify the `display_name` attribute to override it.
+    If the currently installed project version is already past the specified deprecation version,
+    a :exc:`DeprecationWarning` will be raised as a full exception. Otherwise it will just get emitted
+    as a warning.
+
+    The deprecation message used will be constructed based on the input parameters.
+
+    :param display_name:
+        Name of the object that got deprecated (such as ``my_function``).
+
+        By default, the object name is obtained automatically from ``__qualname__`` (falling back
+        to ``__name__``) of the decorated object. Setting this explicitly will override this obtained
+        name and the ``display_name`` will be used instead.
+    :param removal_version:
+        Version at which this object should be considered as deprecated and should no longer be used.
+    :param replacement: A new alternative to this (now deprecated) object.
+    :param extra_msg: Additional message included in the deprecation warning/exception at the end.
     """
 
     def inner(func: Callable[P, R]) -> Callable[P, R]:

--- a/mcproto/utils/version.py
+++ b/mcproto/utils/version.py
@@ -23,9 +23,9 @@ _NUMBER_RE = re.compile("[0-9]+")
 
 @dataclass
 class SemanticVersion:
-    """Comparable representation of versions.
+    """Comparable representation of semantic project versions.
 
-    Relies on Semantic Versioning specification (see <https://semver.org/>).
+    .. seealso:: `Semantic Versioning specification. <https://semver.org>`_
     """
 
     version: tuple[int, int, int]
@@ -34,7 +34,7 @@ class SemanticVersion:
 
     @classmethod
     def from_string(cls, string_version: str) -> Self:
-        """Build a semantic version instance from a string being the entire version tag."""
+        """Build an instance from the semantic version passed as a string"""
         match = _SEMVER_REGEX.match(string_version)
         if not match:
             raise ValueError(f"Invalid version: {string_version!r} (not a semantic version)")
@@ -51,14 +51,17 @@ class SemanticVersion:
 
     @property
     def major(self) -> int:
+        """Major version number of the semantic version."""
         return self.version[0]
 
     @property
     def minor(self) -> int:
+        """Minor version number of the semantic version."""
         return self.version[1]
 
     @property
     def patch(self) -> int:
+        """Patch version number of the semantic version."""
         return self.version[2]
 
     def __str__(self) -> str:
@@ -93,7 +96,7 @@ class SemanticVersion:
 
     @staticmethod
     def _lt_prerelease(prerelease1: tuple[str, ...], prerelease2: tuple[str, ...]) -> bool:
-        """Perform a less than comparison on pre-release versions (prerelease1 < prerelease2).
+        """Perform a less than comparison on pre-release versions (``prerelease1`` < ``prerelease2``).
 
         This check is based on the semantic version rules:
             - A larger set of pre-release fields has higher precedence (if all preceding identifiers are equal)

--- a/mcproto/utils/version_map.py
+++ b/mcproto/utils/version_map.py
@@ -27,22 +27,22 @@ class WalkableModuleData(NamedTuple):
 class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
     """Base class for map classes that allow obtaining versioned implementations for same components.
 
-    Some components (classes) need to be versioned as they might change between different protocol
-    versions. VersionMap classes are responsible for finding the implementation for given component
-    that matches the requested version for.
+    Some components (classes, functions, constants, ...) need to be versioned as they might change
+    between different protocol versions. :class:`.VersionMap` classes are responsible for finding the
+    implementation for given component that matches the requested version for.
 
     If the exact requested version is not found, the closest older/lesser version will be used instead,
     however as this might cause issues, a user warning will be produced alongside this happening.
 
-    NOTE: If you need typed implementations, you are advised to instead import the versioned class
-    directly, as due to the dynamic nature of this map, and the changing nature of the versioned
-    implementations, no type information can be provided here.
+    .. note:
+        If you need typed implementations, you should import the versioned components directly, as due
+        to the dynamic nature of this map, and the changing nature of the versioned implementations,
+        no type information can be provided here.
 
-    WARNING: You are not expected to initialize these mapping classes! That should be left for the
-    library to handle and provide a map for each individual versioned components.
+    .. warning:
+        You are not expected to initialize these mapping classes yourself! That should be left for
+        the library to handle and provide a map for each individual versioned components.
     """
-
-    # TODO: Describe the obtain key, lazy loading and preload_all in init
 
     # TODO: Look into generating stubs somehow to preserve the type information even with how
     # dynamic this class is. (Could require making this class generic over a literal int, being
@@ -54,13 +54,22 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
         "COMPATIBLE_FALLBACK_VERSIONS",
     ]
 
+    #: Set of all versions that have complete implementations, with package for the version
     SUPPORTED_VERSIONS: ClassVar[set[int]]
+    #: Set of all versions that are fully compatible with an older supported version that they safely fall back to
     COMPATIBLE_FALLBACK_VERSIONS: ClassVar[set[int]]
+    #: Fully qualified name of the package, containing individual versioned packages
     _SEARCH_DIR_QUALNAME: ClassVar[str]
 
     __slots__ = ("_version_map",)
 
     def __init__(self, preload_all: bool = False):
+        """
+        :param preload_all:
+            By default, the individual versioned components are loaded lazily, once requested.
+            However if this is set to ``True``, the components from all :attr:`.SUPPORTED_VERSIONS`
+            will all get loaded on initialization.
+        """
         self._version_map: dict[int, dict[K, V]] = {}
 
         if preload_all:
@@ -68,7 +77,15 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
                 self.load_version(version)
 
     def load_version(self, protocol_version: int) -> None:
-        """Load all components for given protocol version."""
+        """Load all components for given protocol version.
+
+        Go through all versioned components found for the requested version (from all submodules in the
+        package for given version.) and store them into an internal version map. Each component is stored
+        under it's corresponding obtain key.
+
+        :raises ValueError:
+            Raised if a key collision occurs (obtain key of multiple distinct versioned components is the same).
+        """
         for key, member in self._walk_valid_components(protocol_version):
             dct = self._version_map.setdefault(protocol_version, {})
 
@@ -78,7 +95,18 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
             dct[key] = member
 
     def obtain(self, protocol_version: int, key: K) -> V:
-        """Obtain component for given protocol version, that matches the obtain key."""
+        """Obtain component for given protocol version, that matches the obtain key.
+
+        This function works lazily, and only loads the required components for given ``protocol_version``
+        if they're not already loaded. If loading does occr, the requested version is stored internally
+        and will simply be accessed next time this function is called with the same ``protocol_version``.
+
+        Once loaded, a versioned component that matches the given obtain ``key`` is returned.
+
+        .. note:
+            If given ``protocol_version`` isn't supported, a fallback version is picked
+            (see: :meth:`._get_supported_protocol_version`).
+        """
         protocol_version = self._get_supported_protocol_version(protocol_version)
 
         # Lazy loading: if this protocol version isn't in the version map, it wasn't yet loaded, do so now.
@@ -88,7 +116,18 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
         return self._version_map[protocol_version][key]
 
     def make_version_map(self, protocol_version: int) -> dict[K, V]:
-        """Construct a dictionary mapping (obtain key -> value) for values of given protocol version."""
+        """Obtain a dictionary mapping of obtain key -> versioned component, with all components for given version.
+
+        This function works lazily, and only loads the required components for given ``protocol_version``
+        if they're not already loaded. If loading does occur, the requested version is stored internally and
+        will simply be accessed next time this function is called with the same ``protocol_version``.
+
+        The returned dictionary is a copy of the internal one, as we don't want the user to be able to modify it.
+
+        .. note:
+            If given ``protocol_version`` isn't supported, a fallback version is picked
+            (see: :meth:`._get_supported_protocol_version`).
+        """
         protocol_version = self._get_supported_protocol_version(protocol_version)
 
         # Lazy loading: if this protocol version isn't in the version map, it wasn't yet loaded, do so now.
@@ -99,33 +138,38 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
 
     @abstractmethod
     def _check_obj(
-        self, obj: Any, module_data: WalkableModuleData, protocol_version: int  # noqa: ANN401
+        self,
+        obj: Any,  # noqa: ANN401
+        module_data: WalkableModuleData,
+        protocol_version: int,
     ) -> TypeGuard[V]:
         """Determine whether a member object should be considered as a valid component for given protocol version.
 
-        This method will be called for each potential member object (found when walking over all members of
-        __all__ from all submodules of the package for given protocol version).
+        When versioned components are obtained, all of the members listed in any module's ``__all__`` are
+        considered. This function serves as a filter, identifying whether a potential member object should be
+        considered as one of the versioned components.
 
-        This function shouldn't include any checks on whether an object is already registered in the version map
-        (key collisions), these are handled during the collection in load_version, all this function is responsible
-        for is checking whether this object is a valid component, components with conflicting keys are still
-        considered valid here, as they're handled elsewhere.
+        .. note:
+            This function shouldn't include any checks on whether an object is already registered in the version
+            map (key collisions), these are handled during the collection in :meth:`.load_version`, all this
+            function is responsible for is checking whether this object is a valid component, components with
+            conflicting keys are still considered valid here, as they're handled elsewhere.
 
-        Although if there is some additional data that needs to be unique for a component to be valid, which wouldn't
-        be caught as a key collision, this function can raise a ValueError.
+            However if there is some additional data that needs to be unique for a component to be valid, which
+            wouldn't be caught as a key collision, this function can raise a :exc:`ValueError`.
         """
         raise NotImplementedError
 
     @classmethod
     @abstractmethod
     def _make_obtain_key(cls, obj: V, module_data: WalkableModuleData, protocol_version: int) -> K:
-        """Construct a unique obtain key for given object under given protocol version.
+        """Construct a unique obtain key for given versioned component (``obj``) under given ``protocol_version``.
 
-
-        Note: While the protocol version might be beneficial to know when constructing
-        the obtain key, it shouldn't be used directly as a part of the key, as the items
-        will already be split by their protocol versions, and this version will be known
-        at obtaining time.
+        .. note:
+            While the protocol version might be beneficial to know when constructing
+            the obtain key, it shouldn't be used directly as a part of the key, as the items
+            will already be split by their protocol versions, and this version will be known
+            at obtaining time.
         """
         raise NotImplementedError
 
@@ -133,7 +177,8 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
     def _get_package_module(cls, protocol_version: int) -> ModuleType:
         """Obtain the package module containing all components specific to given protocol version.
 
-        This relies on the _SEARCH_DIR_QUALNAME and naming scheme of v{protocol_version} for the modules.
+        This relies on the :attr:`._SEARCH_DIR_QUALNAME` class variable, and naming scheme of
+        v{protocol_version} for the modules contained in this directory.
         """
         module_name = f"{cls._SEARCH_DIR_QUALNAME}.v{protocol_version}"
         try:
@@ -147,13 +192,13 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
 
     @classmethod
     def _walk_submodules(cls, module: ModuleType) -> Iterator[WalkableModuleData]:
-        """Go over all submodules of given module, that properly specify __all__.
+        """Go over all submodules of given module, that specify ``__all__``.
 
         The yielded modules are expected to contain the versioned component items.
 
-        If a submodule that doesn't define __all__ is present, it will be skipped, as we don't
+        If a submodule that doesn't define ``__all__`` is present, it will be skipped, as we don't
         consider it walkable. (Walking over all variables defined in this module isn't viable,
-        since it would include imports etc. making defining __all__ a requirement.)
+        since it would include imports etc. making defining ``__all__`` a requirement.)
         """
 
         def on_error(name: str) -> NoReturn:
@@ -177,9 +222,16 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
 
     @classmethod
     def _walk_members(cls, module_data: WalkableModuleData) -> Iterator[object]:
-        """Go over all members specified in __all__ of given walkable (sub)module.
+        """Go over all members specified in ``__all__`` of given walkable (sub)module.
 
-        Yields all
+        :return:
+            Iterator yielding every object defined in ``__all__`` of given module. These objects
+            are obtained directly using ``getattr`` from the imported module.
+
+        :raises TypeError:
+            Raised when an attribute defined in ``__all__`` can't be obtained using ``getattr``.
+            This would suggest the module has incorrectly defined ``__all__``, as it includes values
+            that aren't actually defined in the module.
         """
         for member_name in module_data.member_names:
             try:
@@ -191,7 +243,16 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
             yield member
 
     def _walk_valid_components(self, protocol_version: int) -> Iterator[tuple[K, V]]:
-        """Go over all components/members belonging to given protocol version."""
+        """Go over all components/members belonging to given protocol version.
+
+        This method walks over all submodules in the versioned module (see: :meth:`._get_package_module`),
+        in which we go over all members present in ``__all__`` of this submodule (see :meth:`._walk_submodules`),
+        after which a :meth:`_check_obj` check is performed, ensuring the obtained member/component is one that
+        should be versioned.
+
+        :return:
+            A tuple containing the obtain key (see: :meth:`._make_obtain_key`), and the versioned component/member.
+        """
         version_module = self._get_package_module(protocol_version)
         for module_data in self._walk_submodules(version_module):
             for member in self._walk_members(module_data):
@@ -200,15 +261,18 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
                     yield key, member
 
     def _get_supported_protocol_version(self, protocol_version: int) -> int:
-        """Given a protocol version, return closest older supported version, or the version itself.
+        """Given a ``protocol_version``, return closest older supported version, or the version itself.
 
-        - If given protocol version is one of supported versions, this function will simply return it.
-        - Otherwise, search for the closest older version to the requested version
-            - If there is no older version in the supported version, ValueError is raised
-            - If the requested version is in COMPATIBLE_FALLBACK_VERSIONS, this fallback will be
+        * If given ``protocol_version`` is one of :attr:`.SUPPORTED_VERSIONS`, return it.
+        * Otherwise, search for the closest older supported version to the provided ``protocol_version``.
+            * If there is no older version in the supported version, :exc:`ValueError` is raised
+            * If the requested version is in :attr:`.COMPATIBLE_FALLBACK_VERSIONS`, this fallback will be
               considered safe, and no errors/warnings will be produced.
-            - Otherwise, the closest version will still be returned, but a UserWarning will be emitted
+            * Otherwise, the closest version will still be returned, but a :exc:`UserWarning` will be emitted
               mentioning that this fallback occurred and that the version might not be fully compatible.
+
+        :raises ValueError:
+            The requested version isn't supported, and there is no supported older version to fallback to.
         """
 
         if protocol_version in self.SUPPORTED_VERSIONS:

--- a/tests/mcproto/protocol/helpers.py
+++ b/tests/mcproto/protocol/helpers.py
@@ -10,17 +10,17 @@ class WriteFunctionMock(Mock):
         self.combined_data = bytearray()
 
     def __call__(self, data: bytearray) -> None:
-        """Override mock's __call__ to extend our combined_data bytearray.
+        """Override mock's ``__call__`` to extend our :attr:`.combined_data` bytearray.
 
         This allows us to keep track of exactly what data was written by the mocked write function
-        in total, rather than only having tools like assert_called_with, which don't combine the
-        data of each call.
+        in total, rather than only having tools like :meth:`.assert_called_with`, which might let us
+        get the data from individual calls, but not the combined data, which is what we'll need.
         """
         self.combined_data.extend(data)
         return super().__call__(data)
 
     def assert_has_data(self, data: bytearray, ensure_called: bool = True) -> None:
-        """Ensure that the total data to write by the mocked function matches expected data."""
+        """Ensure that the combined write data by the mocked function matches expected ``data``."""
         if ensure_called:
             self.assert_called()
 
@@ -40,17 +40,22 @@ class ReadFunctionMock(Mock):
         self.combined_data = combined_data
 
     def __call__(self, length: int) -> bytearray:
-        """Override mock's __call__ to make it return part of our combined_data bytearray.
+        """Override mock's __call__ to make it return part of our :attr:`.combined_data` bytearray.
 
-        This allows us to define the combined data we want the mocked read function to be
-        returning, and have each call only take requested part (length) of that data.
+        This allows us to make the return value always be the next requested part (length) of
+        the :attr:`.combined_data`. It would be difficult to replicate this with regular mocks,
+        because some functions can end up making multiple read calls, and each time the result
+        needs to be different (the next part).
         """
         self.return_value = self.combined_data[:length]
         del self.combined_data[:length]
         return super().__call__(length)
 
-    def assert_read_everything(self) -> None:
-        """Ensure that the passed combined_data was fully read and depleted by one, or more calls."""
+    def assert_read_everything(self, ensure_called: bool = True) -> None:
+        """Ensure that the passed :attr:`.combined_data` was fully read and depleted."""
+        if ensure_called:
+            self.assert_called()
+
         if len(self.combined_data) != 0:
             raise AssertionError(
                 f"Read function didn't deplete all of it's data, remaining data: {self.combined_data!r}"

--- a/tests/mcproto/protocol/test_base_io.py
+++ b/tests/mcproto/protocol/test_base_io.py
@@ -27,17 +27,19 @@ from tests.mcproto.protocol.helpers import (
 
 
 class SyncWriter(BaseSyncWriter):
-    """Initializable concrete implementation of BaseSyncWriter ABC."""
+    """Initializable concrete implementation of :class:`~mcproto.protocol.base_io.BaseSyncWriter` ABC."""
 
     def write(self, data: bytearray) -> None:
         """Concrete implementation of abstract write method.
 
-        Since classes using abc.ABC can't be initialized if they have any abstract methods
-        which weren't overridden with a concrete implementation, this is a fake implementation,
+        Since :class:`abc.ABC` classes can't be initialized if they have any abstract methods
+        which weren't overridden with a concrete implementations, this is a fake implementation,
         without any actual logic, purely to allow the initialization of this class.
 
-        This method is expected to be mocked using WriteFunctionMock if it's expected to get called
-        during testing. If this method gets called without being mocked, it will raise NotImplementedError.
+        This method is expected to be mocked using :class:`~tests.mcproto.protocol.helpers.WriteFunctionMock`
+        if it's supposed to get called during testing.
+
+        If this method gets called without being mocked, it will raise :exc:`NotImplementedError`.
         """
         raise NotImplementedError(
             "This concrete override of abstract write method isn't intended for actual use!\n"
@@ -49,17 +51,19 @@ class SyncWriter(BaseSyncWriter):
 
 
 class SyncReader(BaseSyncReader):
-    """Testable concrete implementation of BaseSyncReader ABC."""
+    """Testable concrete implementation of :class:`~mcproto.protocol.base_io.BaseSyncReader` ABC."""
 
     def read(self, length: int) -> bytearray:
         """Concrete implementation of abstract read method.
 
-        Since classes using abc.ABC can't be initialized if they have any abstract methods
-        which weren't overridden with a concrete implementation, this is a fake implementation,
+        Since :class:`abc.ABC` classes can't be initialized if they have any abstract methods
+        which weren't overridden with a concrete implementations, this is a fake implementation,
         without any actual logic, purely to allow the initialization of this class.
 
-        This method is expected to be mocked using ReadFunctionMock if it's expected to get called
-        during testing. If this method gets called without being mocked, it will raise NotImplementedError.
+        This method is expected to be mocked using :class:`~tests.mcproto.protocol.helpers.ReadFunctionMock`
+        if it's supposed to get called during testing.
+
+        If this method gets called without being mocked, it will raise :exc:`NotImplementedError`.
         """
         raise NotImplementedError(
             "This concrete override of abstract read method isn't intended for actual use!\n"
@@ -71,17 +75,19 @@ class SyncReader(BaseSyncReader):
 
 
 class AsyncWriter(BaseAsyncWriter):
-    """Initializable concrete implementation of BaseAsyncWriter ABC."""
+    """Initializable concrete implementation of :class:`~mcproto.protocol.base_io.BaseAsyncWriter` ABC."""
 
     async def write(self, data: bytearray) -> None:
         """Concrete implementation of abstract write method.
 
-        Since classes using abc.ABC can't be initialized if they have any abstract methods
-        which weren't overridden with a concrete implementation, this is a fake implementation,
+        Since :class:`abc.ABC` classes can't be initialized if they have any abstract methods
+        which weren't overridden with a concrete implementations, this is a fake implementation,
         without any actual logic, purely to allow the initialization of this class.
 
-        This method is expected to be mocked using WriteFunctionAsyncMock if it's expected to get called
-        during testing. If this method gets called without being mocked, it will raise NotImplementedError.
+        This method is expected to be mocked using :class:`~tests.mcproto.protocol.helpers.WriteFunctionAsyncMock`
+        if it's supposed to get called during testing.
+
+        If this method gets called without being mocked, it will raise :exc:`NotImplementedError`.
         """
         raise NotImplementedError(
             "This concrete override of abstract write method isn't intended for actual use!\n"
@@ -98,12 +104,14 @@ class AsyncReader(BaseAsyncReader):
     async def read(self, length: int) -> bytearray:
         """Concrete implementation of abstract read method.
 
-        Since classes using abc.ABC can't be initialized if they have any abstract methods
-        which weren't overridden with a concrete implementation, this is a fake implementation,
+        Since :class:`abc.ABC` classes can't be initialized if they have any abstract methods
+        which weren't overridden with a concrete implementations, this is a fake implementation,
         without any actual logic, purely to allow the initialization of this class.
 
-        This method is expected to be mocked using ReadFunctionAsyncMock if it's expected to get called
-        during testing. If this method gets called without being mocked, it will raise NotImplementedError.
+        This method is expected to be mocked using :class:`~tests.mcproto.protocol.helpers.ReadFunctionAsyncMock`
+        if it's supposed to get called during testing.
+
+        If this method gets called without being mocked, it will raise :exc:`NotImplementedError`.
         """
         raise NotImplementedError(
             "This concrete override of abstract read method isn't intended for actual use!\n"
@@ -119,7 +127,10 @@ class AsyncReader(BaseAsyncReader):
 
 
 class WrappedAsyncReader(SynchronizedMixin):
-    """Wrapped synchronous implementation of asynchronous AsyncReader class."""
+    """Wrapped synchronous implementation of asynchronous :class:`.AsyncReader` class.
+
+    This essentially mimics :class:`~mcproto.protocol.base_io.BaseSyncReader`.
+    """
 
     _WRAPPED_ATTRIBUTE = "_reader"
 
@@ -128,7 +139,10 @@ class WrappedAsyncReader(SynchronizedMixin):
 
 
 class WrappedAsyncWriter(SynchronizedMixin):
-    """Wrapped synchronous implementation of asynchronous AsyncWriter class."""
+    """Wrapped synchronous implementation of asynchronous :class:`.AsyncWriter` class.
+
+    This essentially mimics :class:`~mcproto.protocol.base_io.BaseSyncWriter`.
+    """
 
     _WRAPPED_ATTRIBUTE = "_writer"
 
@@ -462,7 +476,7 @@ class ReaderTests(ABC):
 
 
 class TestBaseSyncWriter(WriterTests):
-    """Tests for individual write methods implemented in BaseSyncWriter."""
+    """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncWriter`."""
 
     @classmethod
     def setup_class(cls):
@@ -471,7 +485,7 @@ class TestBaseSyncWriter(WriterTests):
 
 
 class TestBaseSyncReader(ReaderTests):
-    """Tests for individual write methods implemented in BaseSyncReader."""
+    """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncReader`."""
 
     @classmethod
     def setup_class(cls):
@@ -480,7 +494,7 @@ class TestBaseSyncReader(ReaderTests):
 
 
 class TestBaseAsyncWriter(WriterTests):
-    """Tests for individual write methods implemented in BaseAsyncWriter."""
+    """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncReader`."""
 
     writer: WrappedAsyncWriter
 
@@ -490,7 +504,7 @@ class TestBaseAsyncWriter(WriterTests):
 
 
 class TestBaseAsyncReader(ReaderTests):
-    """Tests for individual write methods implemented in BaseAsyncReader."""
+    """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncReader`."""
 
     reader: WrappedAsyncReader
 


### PR DESCRIPTION
This converts all docstrings in the library to use sphinx style, getting the codebase ready for auto-generated docs, that pick these docstrings up.

On top of just conversion to a different format, this does also make some general improvements to the wording in some places, and perhaps even adds new docstrings for undocumented things.

- [x] Convert all docstrings in the project to use sphinx style
- [x] Also convert docstrings in `tests/`, even though these won't be in docs, we want consistency

This PR is a part of #19.