### PR TITLE
Increase the stack level for version fallback warnings

### DIFF
--- a/changes/75.bugfix.md
+++ b/changes/75.bugfix.md
@@ -1,0 +1,1 @@
+Increase the stack level of warnings shown on protocol version fallbacks

--- a/mcproto/utils/version_map.py
+++ b/mcproto/utils/version_map.py
@@ -295,6 +295,7 @@ class VersionMap(ABC, RequiredParamsABCMixin, Generic[K, V]):
                 f"Falling back to older protocol version {protocol_version_closest}, "
                 f"as the requested version ({protocol_version}) isn't supported.",
                 category=UserWarning,
+                stacklevel=3,
             )
 
         return protocol_version_closest


### PR DESCRIPTION
By default, warnings use a stack-level of 1, which means only the context of the warning call would be shown (i.e. the function in which this happened). This increases the stack-level to 3, as this is an internal fuction, only expected to be called from other functions, which are then potentially called by the user.

Resolves a new bugbear issue caught in #69