### PR TITLE
Make sure TCP connections end gracefully

### DIFF
--- a/changes/113.bugfix.md
+++ b/changes/113.bugfix.md
@@ -1,0 +1,1 @@
+TCP connections now properly shut down the connection gracefully (TCP FIN)

--- a/tests/mcproto/test_connection.py
+++ b/tests/mcproto/test_connection.py
@@ -36,6 +36,9 @@ class MockSocket(CustomMockMixin, MagicMock):
     def close(self) -> None:
         self._closed = True
 
+    def shutdown(self, __how: int, /) -> None:
+        pass
+
 
 class MockStreamWriter(CustomMockMixin, MagicMock):
     spec_set = asyncio.StreamWriter


### PR DESCRIPTION
TCP connections establish sessions, and expect graceful shut downs (FIN packet). Make sure on connection close, this packet gets sent.

While not having this shutdown functionality should generally not affect us getting the data from the server, or any other functionality of the library, it is a good practice, and some very aggressive firewalls might actually detect and block IPs that don't properly close their TCP connections if this happens multiple times. 