### PR TITLE
Enable version selection in docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,15 +4,12 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
-  commands:
-    - pip install poetry
-    - poetry config virtualenvs.create false
-    - poetry install --only main,docs,docs-ci
-    - poetry run poetry-dynamic-versioning
-    - poetry run task docs
-    - mkdir ./_readthedocs
-    - mv ./docs/_build/html ./_readthedocs
-
+  jobs:
+    post_install:
+      - pip install poetry
+      - poetry config virtualenvs.create false
+      - poetry install --only main,docs,docs-ci
+      - poetry run poetry-dynamic-versioning
 
 sphinx:
   builder: dirhtml


### PR DESCRIPTION
Don't specify full sphinx-build commands in readthedocs configuration, let readthedocs handle that, only specify the preparation steps (installing dependencies and poetry).

This is important because when readthedocs builds this page, some environmental variables are set which furo theme picks up on, and for example adds the version selector menu, or similar readthedocs features to the built documentation, whcih wouldn't otherwise be there when building ourselves.