### PR TITLE
Enforce PEP 698 (override decorator)

### DIFF
--- a/changes/131.internal.md
+++ b/changes/131.internal.md
@@ -1,0 +1,1 @@
+Any overridden methods in any classes now have to explicitly use the `typing.override` decorator (see [PEP 698](https://peps.python.org/pep-0698/))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,7 @@ from datetime import date
 from pathlib import Path
 
 from packaging.version import parse as parse_version
+from typing_extensions import override
 
 if sys.version_info >= (3, 11):
     from tomllib import load as toml_parse
@@ -172,6 +173,7 @@ def mock_autodoc() -> None:
     from sphinx.ext import autodoc
 
     class MockedClassDocumenter(autodoc.ClassDocumenter):
+        @override
         def add_line(self, line: str, source: str, *lineno: int) -> None:
             if line == "   Bases: :py:class:`object`":
                 return

--- a/docs/extensions/attributetable.py
+++ b/docs/extensions/attributetable.py
@@ -14,6 +14,7 @@ from sphinx.locale import _ as translate
 from sphinx.util.docutils import SphinxDirective
 from sphinx.util.typing import OptionSpec
 from sphinx.writers.html5 import HTML5Translator
+from typing_extensions import override
 
 
 class AttributeTable(nodes.General, nodes.Element):
@@ -111,6 +112,7 @@ class PyAttributeTable(SphinxDirective):
 
         return modulename, name
 
+    @override
     def run(self) -> list[AttributeTablePlaceholder]:
         """If you're curious on the HTML this is meant to generate:
 

--- a/mcproto/auth/account.py
+++ b/mcproto/auth/account.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import httpx
+from typing_extensions import override
 
 from mcproto.types.uuid import UUID as McUUID  # noqa: N811
 
@@ -22,6 +23,7 @@ class MismatchedAccountInfoError(Exception):
         self.expected = expected
         super().__init__(repr(self))
 
+    @override
     def __repr__(self) -> str:
         msg = f"Account has mismatched {self.missmatched_variable}: "
         msg += f"current={self.current!r}, expected={self.expected!r}."

--- a/mcproto/auth/microsoft/oauth.py
+++ b/mcproto/auth/microsoft/oauth.py
@@ -5,6 +5,7 @@ from enum import Enum
 from typing import TypedDict
 
 import httpx
+from typing_extensions import override
 
 __all__ = [
     "MicrosoftOauthResponseErrorType",
@@ -67,6 +68,7 @@ class MicrosoftOauthResponseError(Exception):
             return f"Unknown error: {self.error!r}"
         return f"Error {self.err_type.name}: {self.err_type.value!r}"
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.msg!r})"
 

--- a/mcproto/auth/microsoft/xbox.py
+++ b/mcproto/auth/microsoft/xbox.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import NamedTuple
 
 import httpx
+from typing_extensions import override
 
 __all__ = [
     "XSTSErrorType",
@@ -76,6 +77,7 @@ class XSTSRequestError(Exception):
 
         return " ".join(msg_parts)
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.msg})"
 

--- a/mcproto/auth/msa.py
+++ b/mcproto/auth/msa.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 
 import httpx
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.auth.account import Account
 from mcproto.types.uuid import UUID as McUUID  # noqa: N811
@@ -59,6 +59,7 @@ class ServicesAPIError(Exception):
 
         return " ".join(msg_parts)
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.msg})"
 

--- a/mcproto/auth/yggdrasil.py
+++ b/mcproto/auth/yggdrasil.py
@@ -5,7 +5,7 @@ from enum import Enum
 from uuid import uuid4
 
 import httpx
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.auth.account import Account
 from mcproto.types.uuid import UUID as McUUID  # noqa: N811
@@ -102,6 +102,7 @@ class AuthServerApiError(Exception):
 
         return " ".join(msg_parts)
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.msg})"
 

--- a/mcproto/buffer.py
+++ b/mcproto/buffer.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing_extensions import override
+
 from mcproto.protocol.base_io import BaseSyncReader, BaseSyncWriter
 
 __all__ = ["Buffer"]
@@ -14,10 +16,12 @@ class Buffer(BaseSyncWriter, BaseSyncReader, bytearray):
         super().__init__(*args, **kwargs)
         self.pos = 0
 
+    @override
     def write(self, data: bytes) -> None:
         """Write/Store given ``data`` into the buffer."""
         self.extend(data)
 
+    @override
     def read(self, length: int) -> bytearray:
         """Read data stored in the buffer.
 
@@ -52,6 +56,7 @@ class Buffer(BaseSyncWriter, BaseSyncReader, bytearray):
         finally:
             self.pos = end
 
+    @override
     def clear(self, only_already_read: bool = False) -> None:
         """Clear out the stored data and reset position.
 

--- a/mcproto/multiplayer.py
+++ b/mcproto/multiplayer.py
@@ -7,6 +7,7 @@ from typing import TypedDict
 import httpx
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+from typing_extensions import override
 
 from mcproto.auth.account import Account
 
@@ -75,6 +76,7 @@ class UserJoinRequestFailedError(Exception):
 
         return " ".join(msg_parts)
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.msg})"
 
@@ -97,6 +99,7 @@ class UserJoinCheckFailedError(Exception):
         self.client_ip = client_ip
         super().__init__(repr(self))
 
+    @override
     def __repr__(self) -> str:
         msg = "Unable to verify user join for "
         msg += f"username={self.client_username!r}, server_hash={self.server_hash!r}, client_ip={self.client_ip!r}"

--- a/mcproto/packets/handshaking/handshake.py
+++ b/mcproto/packets/handshaking/handshake.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import IntEnum
 from typing import ClassVar, final
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.buffer import Buffer
 from mcproto.packets.packet import GameState, ServerBoundPacket
@@ -58,8 +58,8 @@ class Handshake(ServerBoundPacket):
         self.server_port = server_port
         self.next_state = next_state
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_varint(self.protocol_version)
         buf.write_utf(self.server_address)
@@ -67,9 +67,9 @@ class Handshake(ServerBoundPacket):
         buf.write_varint(self.next_state.value)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         return cls(
             protocol_version=buf.read_varint(),
             server_address=buf.read_utf(),

--- a/mcproto/packets/login/login.py
+++ b/mcproto/packets/login/login.py
@@ -5,7 +5,7 @@ from typing import ClassVar, cast, final
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat, load_der_public_key
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.buffer import Buffer
 from mcproto.packets.packet import ClientBoundPacket, GameState, ServerBoundPacket
@@ -42,16 +42,16 @@ class LoginStart(ServerBoundPacket):
         self.username = username
         self.uuid = uuid
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_utf(self.username)
         buf.extend(self.uuid.serialize())
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         username = buf.read_utf()
         uuid = UUID.deserialize(buf)
         return cls(username=username, uuid=uuid)
@@ -80,8 +80,8 @@ class LoginEncryptionRequest(ClientBoundPacket):
         self.public_key = public_key
         self.verify_token = verify_token
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         public_key_raw = self.public_key.public_bytes(encoding=Encoding.DER, format=PublicFormat.SubjectPublicKeyInfo)
 
         buf = Buffer()
@@ -90,9 +90,9 @@ class LoginEncryptionRequest(ClientBoundPacket):
         buf.write_bytearray(self.verify_token)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         server_id = buf.read_utf()
         public_key_raw = buf.read_bytearray()
         verify_token = buf.read_bytearray()
@@ -122,16 +122,16 @@ class LoginEncryptionResponse(ServerBoundPacket):
         self.shared_secret = shared_secret
         self.verify_token = verify_token
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_bytearray(self.shared_secret)
         buf.write_bytearray(self.verify_token)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         shared_secret = buf.read_bytearray()
         verify_token = buf.read_bytearray()
         return cls(shared_secret=shared_secret, verify_token=verify_token)
@@ -155,16 +155,16 @@ class LoginSuccess(ClientBoundPacket):
         self.uuid = uuid
         self.username = username
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.extend(self.uuid.serialize())
         buf.write_utf(self.username)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         uuid = UUID.deserialize(buf)
         username = buf.read_utf()
         return cls(uuid, username)
@@ -186,13 +186,13 @@ class LoginDisconnect(ClientBoundPacket):
         """
         self.reason = reason
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         return self.reason.serialize()
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         reason = ChatMessage.deserialize(buf)
         return cls(reason)
 
@@ -217,17 +217,17 @@ class LoginPluginRequest(ClientBoundPacket):
         self.channel = channel
         self.data = data
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_varint(self.message_id)
         buf.write_utf(self.channel)
         buf.write(self.data)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         message_id = buf.read_varint()
         channel = buf.read_utf()
         data = buf.read(buf.remaining)  # All of the remaining data in the buffer
@@ -252,16 +252,16 @@ class LoginPluginResponse(ServerBoundPacket):
         self.message_id = message_id
         self.data = data
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_varint(self.message_id)
         buf.write_optional(self.data, buf.write)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         message_id = buf.read_varint()
         data = buf.read_optional(lambda: buf.read(buf.remaining))
         return cls(message_id, data)
@@ -288,14 +288,14 @@ class LoginSetCompression(ClientBoundPacket):
         """
         self.threshold = threshold
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_varint(self.threshold)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         threshold = buf.read_varint()
         return cls(threshold)

--- a/mcproto/packets/packet.py
+++ b/mcproto/packets/packet.py
@@ -5,7 +5,7 @@ from collections.abc import Sequence
 from enum import IntEnum
 from typing import ClassVar
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.buffer import Buffer
 from mcproto.utils.abc import RequiredParamsABCMixin, Serializable
@@ -46,9 +46,9 @@ class Packet(Serializable, RequiredParamsABCMixin):
     PACKET_ID: ClassVar[int]
     GAME_STATE: ClassVar[GameState]
 
+    @override
     @classmethod
     def deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         try:
             return cls._deserialize(buf)
         except IOError as exc:
@@ -57,7 +57,6 @@ class Packet(Serializable, RequiredParamsABCMixin):
     @classmethod
     @abstractmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         raise NotImplementedError
 
 
@@ -153,5 +152,6 @@ class InvalidPacketContentError(IOError):
 
         return " ".join(msg_parts)
 
+    @override
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.msg})"

--- a/mcproto/packets/status/ping.py
+++ b/mcproto/packets/status/ping.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import ClassVar, final
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.buffer import Buffer
 from mcproto.packets.packet import ClientBoundPacket, GameState, ServerBoundPacket
@@ -29,14 +29,14 @@ class PingPong(ClientBoundPacket, ServerBoundPacket):
         """
         self.payload = payload
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         buf.write_value(StructFormat.LONGLONG, self.payload)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         payload = buf.read_value(StructFormat.LONGLONG)
         return cls(payload)

--- a/mcproto/packets/status/status.py
+++ b/mcproto/packets/status/status.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import Any, ClassVar, final
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.buffer import Buffer
 from mcproto.packets.packet import ClientBoundPacket, GameState, ServerBoundPacket
@@ -20,13 +20,13 @@ class StatusRequest(ServerBoundPacket):
     PACKET_ID: ClassVar[int] = 0x00
     GAME_STATE: ClassVar[GameState] = GameState.STATUS
 
+    @override
     def serialize(self) -> Buffer:  # pragma: no cover, nothing to test here.
-        """Serialize the packet."""
         return Buffer()
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:  # pragma: no cover, nothing to test here.
-        """Deserialize the packet."""
         return cls()
 
 
@@ -46,16 +46,16 @@ class StatusResponse(ClientBoundPacket):
         """
         self.data = data
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the packet."""
         buf = Buffer()
         s = json.dumps(self.data)
         buf.write_utf(s)
         return buf
 
+    @override
     @classmethod
     def _deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize the packet."""
         s = buf.read_utf()
         data_ = json.loads(s)
         return cls(data_)

--- a/mcproto/types/chat.py
+++ b/mcproto/types/chat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from typing import TypedDict, Union, final
 
-from typing_extensions import Self, TypeAlias
+from typing_extensions import Self, TypeAlias, override
 
 from mcproto.buffer import Buffer
 from mcproto.types.abc import MCType
@@ -53,6 +53,7 @@ class ChatMessage(MCType):
         # pragma: no cover
         raise TypeError(f"Found unexpected type ({self.raw.__class__!r}) ({self.raw!r}) in `raw` attribute")
 
+    @override
     def __eq__(self, other: object) -> bool:
         """Check equality between two chat messages.
 
@@ -65,16 +66,16 @@ class ChatMessage(MCType):
 
         return self.raw == other.raw
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the chat message."""
         txt = json.dumps(self.raw)
         buf = Buffer()
         buf.write_utf(txt)
         return buf
 
+    @override
     @classmethod
     def deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize a chat message."""
         txt = buf.read_utf()
         dct = json.loads(txt)
         return cls(dct)

--- a/mcproto/types/uuid.py
+++ b/mcproto/types/uuid.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import uuid
 from typing import final
 
-from typing_extensions import Self
+from typing_extensions import Self, override
 
 from mcproto.buffer import Buffer
 from mcproto.types.abc import MCType
@@ -21,13 +21,13 @@ class UUID(MCType, uuid.UUID):
 
     __slots__ = ()
 
+    @override
     def serialize(self) -> Buffer:
-        """Serialize the UUID."""
         buf = Buffer()
         buf.write(self.bytes)
         return buf
 
+    @override
     @classmethod
     def deserialize(cls, buf: Buffer, /) -> Self:
-        """Deserialize a UUID."""
         return cls(bytes=bytes(buf.read(16)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ reportUnnecessaryCast = "error"
 reportUnnecessaryComparison = "error"
 reportUnnecessaryContains = "error"
 reportUnnecessaryTypeIgnoreComment = "error"
+reportImplicitOverride = "error"
 reportShadowedImports = "error"
 
 [tool.ruff]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ import unittest.mock
 from collections.abc import Callable, Coroutine
 from typing import Any, Generic, TypeVar
 
-from typing_extensions import ParamSpec
+from typing_extensions import ParamSpec, override
 
 T = TypeVar("T")
 P = ParamSpec("P")
@@ -51,6 +51,7 @@ class SynchronizedMixin:
 
     _WRAPPED_ATTRIBUTE: str
 
+    @override
     def __getattribute__(self, __name: str) -> Any:
         """Return attributes of the wrapped object, if the attribute is a coroutine function, synchronize it.
 
@@ -72,6 +73,7 @@ class SynchronizedMixin:
 
         return super().__getattribute__(__name)
 
+    @override
     def __setattr__(self, __name: str, __value: object) -> None:
         """Allow for changing attributes of the wrapped object.
 

--- a/tests/mcproto/protocol/helpers.py
+++ b/tests/mcproto/protocol/helpers.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, Mock
 
+from typing_extensions import override
+
 
 class WriteFunctionMock(Mock):
     """Mock write function, storing the written data."""
@@ -10,6 +12,7 @@ class WriteFunctionMock(Mock):
         super().__init__(*a, **kw)
         self.combined_data = bytearray()
 
+    @override
     def __call__(self, data: bytes) -> None:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Override mock's ``__call__`` to extend our :attr:`.combined_data` bytearray.
 
@@ -20,6 +23,7 @@ class WriteFunctionMock(Mock):
         self.combined_data.extend(data)
         return super().__call__(data)
 
+    @override
     def assert_has_data(self, data: bytearray, ensure_called: bool = True) -> None:
         """Ensure that the combined write data by the mocked function matches expected ``data``."""
         if ensure_called:
@@ -42,6 +46,7 @@ class ReadFunctionMock(Mock):
             combined_data = bytearray()
         self.combined_data = combined_data
 
+    @override
     def __call__(self, length: int) -> bytearray:  # pyright: ignore[reportIncompatibleMethodOverride]
         """Override mock's __call__ to make it return part of our :attr:`.combined_data` bytearray.
 
@@ -54,6 +59,7 @@ class ReadFunctionMock(Mock):
         del self.combined_data[:length]
         return super().__call__(length)
 
+    @override
     def assert_read_everything(self, ensure_called: bool = True) -> None:
         """Ensure that the passed :attr:`.combined_data` was fully read and depleted."""
         if ensure_called:

--- a/tests/mcproto/protocol/test_base_io.py
+++ b/tests/mcproto/protocol/test_base_io.py
@@ -7,6 +7,7 @@ from typing import Any, Generic, TypeVar, Union
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from typing_extensions import override
 
 from mcproto.protocol.base_io import (
     BaseAsyncReader,
@@ -31,6 +32,7 @@ from tests.mcproto.protocol.helpers import (
 class SyncWriter(BaseSyncWriter):
     """Initializable concrete implementation of :class:`~mcproto.protocol.base_io.BaseSyncWriter` ABC."""
 
+    @override
     def write(self, data: bytes) -> None:
         """Concrete implementation of abstract write method.
 
@@ -55,6 +57,7 @@ class SyncWriter(BaseSyncWriter):
 class SyncReader(BaseSyncReader):
     """Testable concrete implementation of :class:`~mcproto.protocol.base_io.BaseSyncReader` ABC."""
 
+    @override
     def read(self, length: int) -> bytearray:
         """Concrete implementation of abstract read method.
 
@@ -79,6 +82,7 @@ class SyncReader(BaseSyncReader):
 class AsyncWriter(BaseAsyncWriter):
     """Initializable concrete implementation of :class:`~mcproto.protocol.base_io.BaseAsyncWriter` ABC."""
 
+    @override
     async def write(self, data: bytes) -> None:
         """Concrete implementation of abstract write method.
 
@@ -103,6 +107,7 @@ class AsyncWriter(BaseAsyncWriter):
 class AsyncReader(BaseAsyncReader):
     """Testable concrete implementation of BaseAsyncReader ABC."""
 
+    @override
     async def read(self, length: int) -> bytearray:
         """Concrete implementation of abstract read method.
 
@@ -576,36 +581,36 @@ class ReaderTests(ABC, Generic[T_READER]):
 class TestBaseSyncWriter(WriterTests[SyncWriter]):
     """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncWriter`."""
 
+    @override
     @classmethod
     def setup_class(cls):
-        """Initialize writer instance to be tested."""
         cls.writer = SyncWriter()
 
 
 class TestBaseSyncReader(ReaderTests[SyncReader]):
     """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncReader`."""
 
+    @override
     @classmethod
     def setup_class(cls):
-        """Initialize reader instance to be tested."""
         cls.reader = SyncReader()
 
 
 class TestBaseAsyncWriter(WriterTests[AsyncWriter]):
     """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncReader`."""
 
+    @override
     @classmethod
     def setup_class(cls):
-        """Initialize writer instance to be tested."""
         cls.writer = WrappedAsyncWriter()  # type: ignore
 
 
 class TestBaseAsyncReader(ReaderTests[AsyncReader]):
     """Tests for individual write methods implemented in :class:`~mcproto.protocol.base_io.BaseSyncReader`."""
 
+    @override
     @classmethod
     def setup_class(cls):
-        """Initialize writer instance to be tested."""
         cls.reader = WrappedAsyncReader()  # type: ignore
 
 

--- a/tests/mcproto/test_connection.py
+++ b/tests/mcproto/test_connection.py
@@ -6,6 +6,7 @@ import socket
 from unittest.mock import MagicMock
 
 import pytest
+from typing_extensions import override
 
 from mcproto.connection import TCPAsyncConnection, TCPSyncConnection
 from tests.helpers import CustomMockMixin
@@ -28,22 +29,26 @@ class MockSocket(CustomMockMixin, MagicMock):
         self._send = WriteFunctionMock()
         self._closed = False
 
+    @override
     def send(self, data: bytearray) -> None:
         """Mock version of send method, raising :exc:`OSError` if the socket was closed."""
         if self._closed:
             raise OSError(errno.EBADF, "Bad file descriptor")
         return self._send(data)
 
+    @override
     def recv(self, length: int) -> bytearray:
         """Mock version of recv method, raising :exc:`OSError` if the socket was closed."""
         if self._closed:
             raise OSError(errno.EBADF, "Bad file descriptor")
         return self._recv(length)
 
+    @override
     def close(self) -> None:
         """Mock version of close method, setting :attr:`_closed` bool flag."""
         self._closed = True
 
+    @override
     def shutdown(self, __how: int, /) -> None:
         """Mock version of shutdown, without any real implementation."""
         pass
@@ -60,12 +65,14 @@ class MockStreamWriter(CustomMockMixin, MagicMock):
         self._write = WriteFunctionMock()
         self._closed = False
 
+    @override
     def write(self, data: bytearray) -> None:
         """Mock version of write method, raising :exc:`OSError` if the writer was closed."""
         if self._closed:
             raise OSError(errno.EBADF, "Bad file descriptor")
         return self._write(data)
 
+    @override
     def close(self) -> None:
         """Mock version of close method, setting :attr:`_closed` bool flag."""
         self._closed = True
@@ -81,6 +88,7 @@ class MockStreamReader(CustomMockMixin, MagicMock):
         self.mock_add_spec(["_read"])
         self._read = ReadFunctionAsyncMock(combined_data=read_data)
 
+    @override
     def read(self, length: int) -> bytearray:
         """Mock version of read, using the mocked read method."""
         return self._read(length)


### PR DESCRIPTION
[PEP 698](https://peps.python.org/pep-0698/) has introduced a new `typing.override` decorator, and suggested that type-checkers add an option to enable strictly enforcing the usage of this decorator for any method override in all classes.

This decorator does 3 things for us:
1. It makes it very easy to immediately see which methods in a class are overriding some inherited method, and which methods are new, introduced by the current class.
2. Consider a scenario where we have a class `Foo`, that defines some method `my_method`, and a class `Bar`, which inherits from `Foo`, and overrides this method with some other custom implementation. What if the parent `Foo` class suddenly renamed the `my_method` method to `my_cool_method`. Once this happened, the `Bar` class would no longer be overriding the `my_method`, but rather defining it as a completely new method, and inheriting the renamed `my_cool_method` from `Foo`. What `typing.override` does is ensure that methods marked with it are in fact overrides, so in this scenario, if `Bar.my_method` was marked as override, there would be a typing error, informing you that `my_method` is not actually inherited from anywhere, and so the override is invalid.
3. The methods decorated with `typing.override` will inherit the original docstring, unless another one is explicitly set. This allows us to reduce the repetition of docstrings fairly significantly. This is even recognized by ruff's flake8-docstrings, so no ugly noqas everywhere.

While the 1st point may be nice, it's not hugely important, however the 2nd point this feature brings could be pretty nice to have enforced, and the 3rd point is also quite neat.

---

This PR was originally only made to see how enforcing this rule would look in the code-base, and I wasn't really sure whether or not to actually enable this enforcement. However, right now, I feel pretty strongly that enabling this is a good idea, and so, the `do-not-merge` tag from this PR was removed.