### PR TITLE
Update version guarantees page

### DIFF
--- a/changes/139.docs.md
+++ b/changes/139.docs.md
@@ -1,0 +1,1 @@
+Add a warning in version guarantees page, explaining pre-release guarantees (breaking changes in minor versions allowed)

--- a/docs/pages/version_guarantees.rst
+++ b/docs/pages/version_guarantees.rst
@@ -13,7 +13,7 @@ breaking change, and what isn't.
 
 First thing to keep in mind is that breaking changes only apply to **publicly documented
 functions and classes**. If it's not listed in the documentation here, it's an internal feature,
-that's it's not considered a part of the public API, and thus is bound to change. This includes
+that isn't considered a part of the public API, and thus is bound to change. This includes
 documented attributes that start with an underscore.
 
 .. note::

--- a/docs/pages/version_guarantees.rst
+++ b/docs/pages/version_guarantees.rst
@@ -1,6 +1,11 @@
 Version Guarantees
 ==================
 
+.. attention::
+   Mcproto is currently in the pre-release phase (pre v1.0.0). During this phase, these guarantees will NOT be
+   followed! This means that **breaking changes can occur in minor version bumps**, though micro version bumps are
+   still strictly for bugfixes, and will not include any features or breaking changes.
+
 This library follows `semantic versioning model <https:semver.org>`_, which means the major version
 is updated every time there is an incompatible (breaking) change made to the public API. However
 due to the fairly dynamic nature of Python, it can be hard to discern what can be considered a

--- a/docs/pages/version_guarantees.rst
+++ b/docs/pages/version_guarantees.rst
@@ -6,15 +6,13 @@ Version Guarantees
    followed! This means that **breaking changes can occur in minor version bumps**, though micro version bumps are
    still strictly for bugfixes, and will not include any features or breaking changes.
 
-This library follows `semantic versioning model <https:semver.org>`_, which means the major version
-is updated every time there is an incompatible (breaking) change made to the public API. However
-due to the fairly dynamic nature of Python, it can be hard to discern what can be considered a
-breaking change, and what isn't.
+This library follows `semantic versioning model <https:semver.org>`_, which means the major version is updated every
+time there is an incompatible (breaking) change made to the public API. However due to the fairly dynamic nature of
+Python, it can be hard to discern what can be considered a breaking change, and what isn't.
 
-First thing to keep in mind is that breaking changes only apply to **publicly documented
-functions and classes**. If it's not listed in the documentation here, it's an internal feature,
-that isn't considered a part of the public API, and thus is bound to change. This includes
-documented attributes that start with an underscore.
+First thing to keep in mind is that breaking changes only apply to **publicly documented functions and classes**. If
+it's not listed in the documentation here, it's an internal feature, that isn't considered a part of the public API,
+and thus is bound to change. This includes documented attributes that start with an underscore.
 
 .. note::
    The examples below are non-exhaustive.


### PR DESCRIPTION
- Mention that pre-release versions don't follow version guarantees
- Fix typo
- Wrap text at 119 chars

This PR is a part of #19 