### PR TITLE
Fix packet compression handling

### DIFF
--- a/changes/159.breaking.md
+++ b/changes/159.breaking.md
@@ -1,0 +1,5 @@
+Fix packet compression handling in the interaction methods.
+
+This fixes a bug that didn't allow for specifying an exact compression threshold that the server specified in `LoginSetCompression` packet, and instead only allowing to toggle between compression on/off, which doesn't really work as server doesn't expect compression for packets below that threshold.
+
+- `sync_write_packet`, `async_write_pakcet`, `sync_read_packet` and `async_read_packet` functions now take `compression_threshold` instead of `compressed` bool flag

--- a/mcproto/packets/interactions.py
+++ b/mcproto/packets/interactions.py
@@ -19,13 +19,40 @@ T_Packet = TypeVar("T_Packet", bound=Packet)
 # | Packet ID   | 32-bit varint |                                       |
 # | Data        | byte array    | Internal data to packet of given id   |
 
+# COMPRESSED PACKET FORMAT:
+# | Compressed? | Field name    | Field type    | Notes                                                             |
+# | ------------|---------------|---------------|-------------------------------------------------------------------|
+# | No          | Packet Length | 32-bit varint | Length of (Data Length) + Compressed length of (Packet ID + Data) |
+# | No          | Data Length   | 32-bit varint | Length of uncompressed (PacketID + Data)                          |
+# | Yes         | Packet ID     | 32-bit varint | Zlib compressed packet ID                                         |
+# | Yes         | Data          | byte array    | Zlib compressed packet data                                       |
+#
+# Compression should only be used when LoginSetCompression packet is received.
+# In this packet, a compression threshold will be sent by the server. This is
+# a number which specifies how large a packet can be at most (it's Data Length),
+# before enabling compression. If a packet is smaller, compression will not be
+# enabled.
+#
+# However since compression changes how the packet format looks, we need to inform
+# the reader whether or not compression was used, so when disabled, we just set
+# Data Length to 0, which will mean compression is disabled, and Packet ID and Data
+# fields will be sent uncompressed.
+
 
 # Since the read functions here require PACKET_MAP, we can't move these functions
 # directly into BaseWriter/BaseReader classes, as that would be a circular import
 
 
-def _serialize_packet(packet: Packet, *, compressed: bool = False) -> Buffer:
-    """Serialize the internal packet data, along with it's packet id."""
+def _serialize_packet(packet: Packet, *, compression_threshold: int = -1) -> Buffer:
+    """Serialize the internal packet data, along with it's packet id.
+
+    :param packet: The packet to serialize.
+    :param compression_threshold:
+        A threshold for the packet length (in bytes), which if surpassed compression should
+        be enabeld. To disable compression, set this to -1. Note that when enabled, even if
+        the threshold isn't crossed, the packet format will be different than with compression
+        disabled.
+    """
     packet_data = packet.serialize()
 
     # Base packet buffer should only contain packet id and internal packet data
@@ -33,11 +60,15 @@ def _serialize_packet(packet: Packet, *, compressed: bool = False) -> Buffer:
     packet_buf.write_varint(packet.PACKET_ID)
     packet_buf.write(packet_data)
 
-    # If we're serializing a packet as compressed, we compress the packet buffer data
-    # and prepend a varint with the size of uncompressed pacekt buffer
-    if compressed:
-        data_length = len(packet_buf)
-        packet_buf = Buffer(gzip.compress(packet_buf))
+    # Compression is enabled
+    if compression_threshold >= 0:
+        # Only run the actual compression step if we cross the threshold, otherwise
+        # send uncompressed data with an extra 0 for data length
+        if len(packet_buf) > compression_threshold:
+            data_length = len(packet_buf)
+            packet_buf = Buffer(gzip.compress(packet_buf))
+        else:
+            data_length = 0
 
         data_buf = Buffer()
         data_buf.write_varint(data_length)
@@ -47,13 +78,30 @@ def _serialize_packet(packet: Packet, *, compressed: bool = False) -> Buffer:
 
 
 def _deserialize_packet(
-    buf: Buffer, packet_map: Mapping[int, type[T_Packet]], *, compressed: bool = False
+    buf: Buffer,
+    packet_map: Mapping[int, type[T_Packet]],
+    *,
+    compressed: bool = False,
 ) -> T_Packet:
-    """Deserialize the packet id and it's internal data."""
+    """Deserialize the packet id and it's internal data.
+
+    :param packet_map:
+        A mapping of packet id (int) -> packet. Should hold all possible packets for the
+        current gamestate and direction. See :func:`~mcproto.packets.packet_map.generate_packet_map`
+    :param compressed:
+        Boolean flag, if compression is enabled, it should be set to ``True``, ``False`` otherwise.
+
+        Note that in the LoginSetCompression packet, we will only see a compression threshold, not
+        a simple bool flag. This threshold is only useful when writing (serializing) the packets,
+        for reading, we only need to know if compression is enabled or not. That is, if the threshold
+        is set to a non-negative number, this should be ``True``.
+    """
     if compressed:
-        buf.read_varint()  # We don't need this uncompressed length
-        compressd_packet_data = buf.read(buf.remaining)
-        buf = Buffer(gzip.decompress(compressd_packet_data))
+        data_length = buf.read_varint()
+        packet_data = buf.read(buf.remaining)
+        # Only run decompression if the threshold was crosed, otherwise the data_length will be
+        # set to 0, indicating no compression was done, read the data normally if that's the case
+        buf = Buffer(gzip.decompress(packet_data)) if data_length != 0 else Buffer(packet_data)
 
     packet_id = buf.read_varint()
     packet_data = buf.read(buf.remaining)
@@ -61,15 +109,43 @@ def _deserialize_packet(
     return packet_map[packet_id].deserialize(Buffer(packet_data))
 
 
-def sync_write_packet(writer: BaseSyncWriter, packet: Packet, *, compressed: bool = False) -> None:
-    """Write given ``packet``."""
-    data_buf = _serialize_packet(packet, compressed=compressed)
+def sync_write_packet(
+    writer: BaseSyncWriter,
+    packet: Packet,
+    *,
+    compression_threshold: int = -1,
+) -> None:
+    """Write given ``packet``.
+
+    :param writer: The connection/writer to send this packet to.
+    :param packet: The packet to be sent.
+    :param compression_threshold:
+        A threshold packet length, whcih if crossed compression should be enabled.
+
+        You can get this number from :class:`~mcproto.packets.login.login.LoginSetCompression` packet.
+        If this packet wasn't sent by the server, set this to -1 (default).
+    """
+    data_buf = _serialize_packet(packet, compression_threshold=compression_threshold)
     writer.write_bytearray(data_buf)
 
 
-async def async_write_packet(writer: BaseAsyncWriter, packet: Packet, *, compressed: bool = False) -> None:
-    """Write given ``packet``."""
-    data_buf = _serialize_packet(packet, compressed=compressed)
+async def async_write_packet(
+    writer: BaseAsyncWriter,
+    packet: Packet,
+    *,
+    compression_threshold: int = -1,
+) -> None:
+    """Write given ``packet``.
+
+    :param writer: The connection/writer to send this packet to.
+    :param packet: The packet to be sent.
+    :param compression_threshold:
+        A threshold packet length, whcih if crossed compression should be enabled.
+
+        You can get this number from :class:`~mcproto.packets.login.login.LoginSetCompression` packet.
+        If this packet wasn't sent by the server, set this to -1 (default).
+    """
+    data_buf = _serialize_packet(packet, compression_threshold=compression_threshold)
     await writer.write_bytearray(data_buf)
 
 
@@ -79,7 +155,25 @@ def sync_read_packet(
     *,
     compressed: bool = False,
 ) -> T_Packet:
-    """Read a packet."""
+    """Read a packet.
+
+    :param reader: The connection/reader to receive this packet from.
+    :param packet_map:
+        A mapping of packet id (number) -> Packet (class).
+
+        This mapping should contain all of the packets for the current gamestate and direction.
+        See :func:`~mcproto.packets.packet_map.generate_packet_map`
+    :param compressed:
+        A boolean flag, representing whether or not compression is enabled.
+
+        You can get this based on :class:`~mcproto.packets.login.login.LoginSetCompression` packet,
+        which will contain a compression threshold value. This threshold is only useful when writing
+        the packets, for reading, we don't care about the specific threshold, we only need to know
+        whether compression is enabled or not. That is, if the threshold is set to a non-negative
+        number, this should be ``True``.
+
+        If this packet wasn't sent by the server, set this to ``False`` (default).
+    """
     data_buf = Buffer(reader.read_bytearray())
     return _deserialize_packet(data_buf, packet_map, compressed=compressed)
 
@@ -90,6 +184,24 @@ async def async_read_packet(
     *,
     compressed: bool = False,
 ) -> T_Packet:
-    """Read a packet."""
+    """Read a packet.
+
+    :param reader: The connection/reader to receive this packet from.
+    :param packet_map:
+        A mapping of packet id (number) -> Packet (class).
+
+        This mapping should contain all of the packets for the current gamestate and direction.
+        See :func:`~mcproto.packets.packet_map.generate_packet_map`
+    :param compressed:
+        A boolean flag, representing whether or not compression is enabled.
+
+        You can get this based on :class:`~mcproto.packets.login.login.LoginSetCompression` packet,
+        which will contain a compression threshold value. This threshold is only useful when writing
+        the packets, for reading, we don't care about the specific threshold, we only need to know
+        whether compression is enabled or not. That is, if the threshold is set to a non-negative
+        number, this should be ``True``.
+
+        If this packet wasn't sent by the server, set this to ``False`` (default).
+    """
     data_buf = Buffer(await reader.read_bytearray())
     return _deserialize_packet(data_buf, packet_map, compressed=compressed)


### PR DESCRIPTION
This fixes a bug in how we previously handled packet compression. Originally, our handling was done based on a boolean, either do enable compression, or don't.

However this doesn't really work, as the way we recognize whether to enable compression is through the server, sending us the `LoginSetCompression` packet, which only contains a compression threshold value. This value can be -1, in which case compression should be disabled, it can also be 0, in which case compression would indeed always be enabled, but for any other value, compression should only be enabled if the packet length surpasses this threshold, and we only know the packet length during writing, so our interaction functions need to be aware of it.

Note that if this threshold isn't crossed, but is set, the packet format still changes (there is an extra varint after packet length, which generally contains the uncompressed length, but when compression wasn't used - below threshold, it will be set to 0, and the packet id and data fields below remain uncompressed).

This PR changes `sync_write_packet` and `async_write_packet` functions and replaces `compressed` bool parameter to `compression_threshold` parameter, which is now being used properly. This however breaks compatibility, as these writer functions are a part of the public API, and the `compressed` parameter will no longer be available. Considering it didn't really even work properly before, it's unlikely that someone was actually using it yet, nevertheless it is a breaking change.

This does also affect how packet reading works, ~~however there is no breaking change, as only the logic needed to change, to account for the possibility of the data length being 0, in which case compression wasn't used. This function still only takes a `compressed` bool flag parameter, rather than a `compression_threshold`, as if the threshold is non-negative, the packet format fundamentally changes, so we should already be reading the packets differently. For that reason, a bool flag is sufficient here, and should just be set to `True` whenever the threshold is >= 0.~~

Edit: Even though that makes logical sense, I've decided against making the reader use `compressed` bool flag, as it might be annoying for the user to have to do `compressed=compresssion_threshold >= 0` every time when calling the function, as opposed to just `compression_threshold=compression_threshold`. So while the reader doesn't need to know this value, it also doesn't hurt to know it, and we just figure out whether or not compression is enabled ourselves, instead of bothering the user with it. Making this a breaking change too. The underlying `_deserialize_packet` function still only takes a `compressed` bool flag though.