### PR TITLE
Re-export packts in gamestate modules

### DIFF
--- a/changes/160.feature.md
+++ b/changes/160.feature.md
@@ -1,0 +1,1 @@
+Re-export the packet classes (or any other objects) from the gamestate modules (`mcproto.packets.handshaking`/`mcproto.packets.login`/...) directly. Allowing simpler imports (`from mcproto.packets.login import LoginStart` instead of `from mcproto.packets.login.login import LoginStart`)

--- a/mcproto/packets/handshaking/__init__.py
+++ b/mcproto/packets/handshaking/__init__.py
@@ -1,1 +1,8 @@
 from __future__ import annotations
+
+from mcproto.packets.handshaking.handshake import Handshake, NextState
+
+__all__ = [
+    "NextState",
+    "Handshake",
+]

--- a/mcproto/packets/login/__init__.py
+++ b/mcproto/packets/login/__init__.py
@@ -1,1 +1,23 @@
 from __future__ import annotations
+
+from mcproto.packets.login.login import (
+    LoginDisconnect,
+    LoginEncryptionRequest,
+    LoginEncryptionResponse,
+    LoginPluginRequest,
+    LoginPluginResponse,
+    LoginSetCompression,
+    LoginStart,
+    LoginSuccess,
+)
+
+__all__ = [
+    "LoginStart",
+    "LoginEncryptionRequest",
+    "LoginEncryptionResponse",
+    "LoginSuccess",
+    "LoginDisconnect",
+    "LoginPluginRequest",
+    "LoginPluginResponse",
+    "LoginSetCompression",
+]

--- a/mcproto/packets/status/__init__.py
+++ b/mcproto/packets/status/__init__.py
@@ -1,1 +1,10 @@
 from __future__ import annotations
+
+from mcproto.packets.status.ping import PingPong
+from mcproto.packets.status.status import StatusRequest, StatusResponse
+
+__all__ = [
+    "PingPong",
+    "StatusRequest",
+    "StatusResponse",
+]


### PR DESCRIPTION
This allows importing like `from mcproto.packets.login import LoginStart` rather than `from mcproto.packets.login.login import LoginStart`.