### PR TITLE
Add check function for minecraft accounts

### DIFF
--- a/changes/171.feature.md
+++ b/changes/171.feature.md
@@ -1,0 +1,1 @@
+Add `Account.check` function, to verify that the access token in use is valid, and the data the Account instance has matches the data minecraft API has.

--- a/mcproto/auth/account.py
+++ b/mcproto/auth/account.py
@@ -1,8 +1,37 @@
 from __future__ import annotations
 
+import httpx
+
 from mcproto.types.uuid import UUID as McUUID  # noqa: N811
 
-__all__ = ["Account"]
+MINECRAFT_API_URL = "https://api.minecraftservices.com"
+
+__all__ = [
+    "Account",
+    "MismatchedAccountInfoError",
+    "InvalidAccountAccessTokenError",
+]
+
+
+class MismatchedAccountInfoError(Exception):
+    def __init__(self, mismatched_variable: str, current: object, expected: object) -> None:
+        self.missmatched_variable = mismatched_variable
+        self.current = current
+        self.expected = expected
+        super().__init__(repr(self))
+
+    def __repr__(self) -> str:
+        msg = f"Account has mismatched {self.missmatched_variable}: "
+        msg += f"current={self.current!r}, expected={self.expected!r}."
+
+        return f"{self.__class__.__name__}({msg!r})"
+
+
+class InvalidAccountAccessTokenError(Exception):
+    def __init__(self, access_token: str, status_error: httpx.HTTPStatusError) -> None:
+        self.access_token = access_token
+        self.status_error = status_error
+        super().__init__("The account access token used is not valid (key expired?)")
 
 
 class Account:
@@ -12,3 +41,29 @@ class Account:
         self.username = username
         self.uuid = uuid
         self.access_token = access_token
+
+    async def check(self, client: httpx.AsyncClient) -> None:
+        """Check with minecraft API whether the account information stored is valid.
+
+        :raises MismatchedAccountInfoError:
+            If the information received from the minecraft API didn't match the information currently
+            stored in the account instance.
+        :raises InvalidAccountAccessTokenError: If the access token is not valid.
+        """
+        res = await client.get(
+            f"{MINECRAFT_API_URL}/minecraft/profile",
+            headers={"Authorization": f"Bearer {self.access_token}"},
+        )
+
+        try:
+            res.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            if exc.response.status_code == 401:
+                raise InvalidAccountAccessTokenError(self.access_token, exc) from exc
+            raise
+        data = res.json()
+
+        if self.uuid != McUUID(data["id"]):
+            raise MismatchedAccountInfoError("uuid", self.uuid, data["id"])
+        if self.username != data["name"]:
+            raise MismatchedAccountInfoError("username", self.username, data["name"])


### PR DESCRIPTION
This adds a `check` function, that makes a request to minecraft servers, verifying the the account token actually works by requesting account info from minecraft API. Alongside, this will raise an exception if the received account info doesn't match the info in the account class (if the name/uuid differs). 