### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,12 +3,12 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
+    post_create_environment:
+      - python -m pip install poetry
     post_install:
-      - pip install poetry
-      - poetry config virtualenvs.create false
-      - poetry install --only main,docs,docs-ci
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only main,docs,docs-ci
       - poetry run poetry-dynamic-versioning
 
 sphinx:

--- a/changes/258.internal.md
+++ b/changes/258.internal.md
@@ -1,0 +1,1 @@
+Fix readthedocs CI


### PR DESCRIPTION
Readthedocs changed the way to handle poetry installation (again). This should fix the readthedocs failing CI.

ref: https://github.com/readthedocs/readthedocs.org/issues/4912#issuecomment-1992286540