### PR TITLE
Update upload/download artifact actions to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: poetry build
 
       - name: Upload build files
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "dist"
           path: "dist/"
@@ -64,7 +64,7 @@ jobs:
             > changelog.txt
 
       - name: Upload release changelog
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v4
         with:
           name: "changelog"
           path: "changelog.txt"
@@ -79,13 +79,13 @@ jobs:
 
     steps:
       - name: Download the distribution files from PR artifact
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: "dist"
           path: "dist/"
 
       - name: Download the changelog from PR artifact
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: "changelog"
 
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Download the distribution files from PR artifact
-        uses: actions/download-artifact@v3.0.2
+        uses: actions/download-artifact@v4
         with:
           name: "dist"
           path: "dist/"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:
-          name: coverage
+          name: coverage.${{ matrix.platform }}.${{ matrix.python-version }}
           path: .coverage.${{ matrix.platform }}.${{ matrix.python-version }}
           retention-days: 1
           if-no-files-found: error
@@ -64,10 +64,11 @@ jobs:
           python-version: 3.11
           install-args: "--no-root --only test"
 
-      - name: Download coverage artifact
+      - name: Download all coverage artifacts
         uses: actions/download-artifact@v4
         with:
-          name: coverage
+          pattern: coverage.*
+          merge-multiple: true # support downloading multiple artifacts to same dir
 
       # Combine all of the coverage files (for each os, python version - from matrix)
       # into a single coverage file (.coverage), and produce a final (combined) coverage report.

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
           mv .coverage .coverage.${{ matrix.platform }}.${{ matrix.python-version }}
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: .coverage.${{ matrix.platform }}.${{ matrix.python-version }}
@@ -65,7 +65,7 @@ jobs:
           install-args: "--no-root --only test"
 
       - name: Download coverage artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: coverage
 


### PR DESCRIPTION
This updates the `actions/download-artifact` and `actions/upload-artifact` from v3 to v4.

This update needs to be done in a single PR, as the upload format has changed in an incompatible way, and updating only one dependency causes the other to fail, which means both dependabot PRs are failing.

Additionally, the move from v3 to v4 has introduced some breaking changes when it comes to using the same upload name multiple times, to extend it with multiple files. We used this to upload coverage files across the multiple matrix runs. The new approach requires creating a new distinctly named upload each time, and we instead pull the all of the uploads at once, using a wildcard pattern. This follows the [suggested migration steps](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md#multiple-uploads-to-the-same-named-artifact).

Superseeds: #240 #241