### PR TITLE
Several updates/fixes to project's CI

### DIFF
--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -1,3 +1,4 @@
+---
 name: Changelog Fragment present
 
 on:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,3 +1,4 @@
+---
 name: Dependabot auto-merge
 on: pull_request_target
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,21 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+# Cancel already running workflows if new ones are scheduled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validation:
+    uses: ./.github/workflows/validation.yml
+
+  unit-tests:
+    uses: ./.github/workflows/unit-tests.yml

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,3 +1,4 @@
+---
 name: Prepare Release
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,4 @@
+---
 name: Publish to PyPI / GitHub
 
 on:

--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -4,8 +4,7 @@ name: Status Embed
 on:
   workflow_run:
     workflows:
-      - Validation
-      - Unit-Tests
+      - CI
     types:
       - completed
 

--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -1,3 +1,4 @@
+---
 name: Status Embed
 
 on:
@@ -14,7 +15,7 @@ concurrency:
 
 jobs:
   status_embed:
-    name:  Send Status Embed to Discord
+    name: Send Status Embed to Discord
     runs-on: ubuntu-latest
     steps:
       # A workflow_run event does not contain all the information
@@ -45,7 +46,7 @@ jobs:
         uses: SebastiaanZ/github-status-embed-for-discord@v0.3.0
         with:
           # Our GitHub Actions webhook
-          webhook_id: '1051784242318815242'
+          webhook_id: "1051784242318815242"
           webhook_token: ${{ secrets.webhook_token }}
 
           # We need to provide the information of the workflow that
@@ -64,5 +65,5 @@ jobs:
 
           # And some additional details
           actor: ${{ github.actor }}
-          repository:  ${{ github.repository }}
+          repository: ${{ github.repository }}
           ref: ${{ github.ref }}

--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -28,7 +28,7 @@ jobs:
           curl -s -H "Authorization: token $GITHUB_TOKEN" ${{ github.event.workflow_run.artifacts_url }} > artifacts.json
           DOWNLOAD_URL=$(cat artifacts.json | jq -r '.artifacts[] | select(.name == "pull-request-payload") | .archive_download_url')
           [ -z "$DOWNLOAD_URL" ] && exit 1
-          wget --quiet --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
+          curl -sSL -H "Authorization: token $GITHUB_TOKEN" -o pull_request_payload.zip $DOWNLOAD_URL || exit 2
           unzip -p pull_request_payload.zip > pull_request_payload.json
           [ -s pull_request_payload.json ] || exit 3
           echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT

--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -62,8 +62,3 @@ jobs:
           pr_number: ${{ steps.pr_info.outputs.pr_number }}
           pr_title: ${{ steps.pr_info.outputs.pr_title }}
           pr_source: ${{ steps.pr_info.outputs.pr_source }}
-
-          # And some additional details
-          actor: ${{ github.actor }}
-          repository: ${{ github.repository }}
-          ref: ${{ github.ref }}

--- a/.github/workflows/status_embed.yml
+++ b/.github/workflows/status_embed.yml
@@ -16,6 +16,7 @@ jobs:
   status_embed:
     name: Send Status Embed to Discord
     runs-on: ubuntu-latest
+
     steps:
       # A workflow_run event does not contain all the information
       # we need for a PR embed. That's why we upload an artifact
@@ -30,10 +31,10 @@ jobs:
           wget --quiet --header="Authorization: token $GITHUB_TOKEN" -O pull_request_payload.zip $DOWNLOAD_URL || exit 2
           unzip -p pull_request_payload.zip > pull_request_payload.json
           [ -s pull_request_payload.json ] || exit 3
-          echo "::set-output name=pr_author_login::$(jq -r '.user.login // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_number::$(jq -r '.number // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_title::$(jq -r '.title // empty' pull_request_payload.json)"
-          echo "::set-output name=pr_source::$(jq -r '.head.label // empty' pull_request_payload.json)"
+          echo "pr_author_login=$(jq -r '.user.login // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_number=$(jq -r '.number // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_title=$(jq -r '.title // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
+          echo "pr_source=$(jq -r '.head.label // empty' pull_request_payload.json)" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false # Allows for matrix sub-jobs to fail without cancelling the rest
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,16 +1,6 @@
 name: Unit-Tests
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
-
-# Cancel already running workflows if new ones are scheduled
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: workflow_call
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
         id: poetry_setup
         uses: ItsDrike/setup-poetry@v1
         with:
-          python-version: 3.11
+          python-version: ${{ matrix.python-version }}
           install-args: "--without lint --without release"
 
       - name: Run pytest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,3 +1,4 @@
+---
 name: Unit-Tests
 
 on: workflow_call

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -26,7 +26,7 @@ jobs:
         id: poetry_setup
         uses: ItsDrike/setup-poetry@v1
         with:
-          python-version: 3.11
+          python-version: 3.12
           install-args: "--without release"
 
       - name: Pre-commit Environment Caching

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,15 +1,6 @@
 name: Validation
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+on: workflow_call
 
 env:
   PRE_COMMIT_HOME: "/home/runner/.cache/pre-commit"

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -37,7 +37,7 @@ jobs:
         run: SKIP=ruff-linter,ruff-formatter,slotscheck,pyright pre-commit run --all-files
 
       - name: Run ruff linter
-        run: ruff check --output-format=full --show-fixes --exit-non-zero-on-fix .
+        run: ruff check --output-format=github --show-fixes --exit-non-zero-on-fix .
 
       - name: Run ruff formatter
         run: ruff format --diff .

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,3 +1,4 @@
+---
 name: Validation
 
 on: workflow_call

--- a/changes/300.internal.md
+++ b/changes/300.internal.md
@@ -1,2 +1,3 @@
 - Fix CI not running unit tests on python 3.8 (only 3.11)
 - Update to use python 3.12 (in validation and as one of the matrix versions in unit-tests workflow)
+- Trigger and run lint and unit-tests workflows form a single main CI workflow.

--- a/changes/300.internal.md
+++ b/changes/300.internal.md
@@ -2,3 +2,4 @@
 - Update to use python 3.12 (in validation and as one of the matrix versions in unit-tests workflow)
 - Trigger and run lint and unit-tests workflows form a single main CI workflow.
 - Only send status embed after the main CI workflow finishes (not for both unit-tests and validation)
+- Use `--output-format=github` for `ruff check` in the validation workflow

--- a/changes/300.internal.md
+++ b/changes/300.internal.md
@@ -1,0 +1,2 @@
+- Fix CI not running unit tests on python 3.8 (only 3.11)
+- Update to use python 3.12 (in validation and as one of the matrix versions in unit-tests workflow)

--- a/changes/300.internal.md
+++ b/changes/300.internal.md
@@ -1,3 +1,4 @@
 - Fix CI not running unit tests on python 3.8 (only 3.11)
 - Update to use python 3.12 (in validation and as one of the matrix versions in unit-tests workflow)
 - Trigger and run lint and unit-tests workflows form a single main CI workflow.
+- Only send status embed after the main CI workflow finishes (not for both unit-tests and validation)

--- a/mcproto/types/nbt.py
+++ b/mcproto/types/nbt.py
@@ -137,8 +137,8 @@ PayloadType: TypeAlias = Union[
     bytes,
     str,
     "NBTag",
-    Sequence["PayloadType"],
-    Mapping[str, "PayloadType"],
+    "Sequence[PayloadType]",
+    "Mapping[str, PayloadType]",
 ]
 """Represents the type of a payload that can be stored in an NBT tag."""
 
@@ -163,17 +163,17 @@ FromObjectType: TypeAlias = Union[
     float,
     bytes,
     str,
-    NBTagConvertible,
-    Sequence["FromObjectType"],
-    Mapping[str, "FromObjectType"],
+    "NBTagConvertible",
+    "Sequence[FromObjectType]",
+    "Mapping[str, FromObjectType]",
 ]
 """Represents any object holding some data that can be converted to an NBT tag(s)."""
 
 FromObjectSchema: TypeAlias = Union[
-    type["NBTag"],
-    type[NBTagConvertible],
-    Sequence["FromObjectSchema"],
-    Mapping[str, "FromObjectSchema"],
+    "type[NBTag]",
+    "type[NBTagConvertible]",
+    "Sequence[FromObjectSchema]",
+    "Mapping[str, FromObjectSchema]",
 ]
 """Represents the type of a schema, used to define how an object should be converted to an NBT tag(s)."""
 
@@ -967,7 +967,7 @@ class CompoundNBT(NBTag):
         ]
     ):
         result = {tag.name: tag.to_object() for tag in self.payload}
-        result = cast(Mapping[str, PayloadType], result)
+        result = cast("Mapping[str, PayloadType]", result)
         result = result if not include_name else {self.name: result}
         if include_schema:
             subschemas = {

--- a/tests/mcproto/test_multiplayer.py
+++ b/tests/mcproto/test_multiplayer.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import sys
+from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import httpx
 import pytest
-from pytest_httpx import HTTPXMock
+
+if sys.version_info > (3, 9) or TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
 
 from mcproto.multiplayer import (
     JoinAcknowledgeData,


### PR DESCRIPTION
This fixes various issues with the current github workflows, and makes several improvements / updates to bring them up to date with standards or to simplify them.

**Note: This PR fixes previously broken Python 3.8 support for the library.** (Further explained below)

- [x] Fix CI not running unit tests on python 3.8 (only 3.11). 
  For some reason, I apparently just hard-coded the python version, even though the CI was running in a matrix, this was missleading, as it lead to the tests never actually running on python 3.8. Over time, this has resulted in some issues and the code wans't actually even runnable on 3.8. This PR also fixes these issues.
- [x] Update to use python 3.12 (in validation and as one of the matrix versions in unit-tests workflow).
  The original workflows were still using 3.11 as the latest python version.
- [x] Trigger and run lint and unit-tests workflows form a single main CI workflow.
  This allows for easier set up of required workflows for the repo, and unifies some logic, like concurrency config, hence reducing code repetition.
- [x] Only send status embed after the main CI workflow finishes (not for both unit-tests and validation).
  Made possible because of the workflow unification. This change reduces the amount of spam in the discord channel with github hooks, as we don't need to see the status of both validation and unit-tests separately, it is more than enough to just have it send back a final status of the unified workflow.
- [x] Fix the status-embed workflow.
  After a recent change made to the project, the code that was uploading a workflow artifact with the PR data has been removed by accident, this adds the code back, this time into the new unified CI workflow.
  
P.S.: The code to make tests runnable on 3.8 is incredibly cursed, but the version will be dropped some time this year, so it's not a huge issue and it is only affecting the tests code, this logic doesn't touch any of the public library code.