### PR TITLE
Switch to basedpyright

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -34,7 +34,7 @@ jobs:
           restore-keys: "precommit-${{ runner.os }}-${{ steps.poetry_setup.outputs-python-version}}-"
 
       - name: Run pre-commit hooks
-        run: SKIP=ruff-linter,ruff-formatter,slotscheck,pyright pre-commit run --all-files
+        run: SKIP=ruff-linter,ruff-formatter,slotscheck,basedpyright pre-commit run --all-files
 
       - name: Run ruff linter
         run: ruff check --output-format=github --show-fixes --exit-non-zero-on-fix .
@@ -45,5 +45,5 @@ jobs:
       - name: Run slotscheck
         run: slotscheck -m mcproto
 
-      - name: Run pyright type checker
-        run: pyright .
+      - name: Run basedpyright type checker
+        run: basedpyright .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,10 +44,10 @@ repos:
 
   - repo: local
     hooks:
-      - id: pyright
-        name: Pyright
-        description: Run pyright type checker
-        entry: poetry run pyright
+      - id: basedpyright
+        name: Based Pyright
+        description: Run basedpyright type checker
+        entry: poetry run basedpyright
         language: system
         types: [python]
         pass_filenames: false # pyright runs for the entire project, it can't run for single files

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,8 @@ poetry install
 Note that you will want to re-run this command each time our dependencies are updated, to stay in sync with the project.
 
 After that, the environment will contain all of the dependencies, including various executable programs, such as
-`pyright`. One of these executable programs is also `python`, which is the python interpreter for this environment,
-capable of interacting with all of the installed libraries.
+`basedpyright`. One of these executable programs is also `python`, which is the python interpreter for this
+environment, capable of interacting with all of the installed libraries.
 
 You will now need to make your terminal use the programs from this environment, rather than any global versions that you
 may have installed, so that you can use the tools in it when working on the project. Some IDEs/editors are capable of
@@ -396,10 +396,13 @@ to run the code. So many times, you'll see issues before actually testing things
 a lot of cases, type checkers can even uncover many things that our unit tests wouldn't find.
 
 There are many python type-checkers available, the most notable ones being `mypy` and `pyright`. We decided to use
-`pyright`, because it has great support for many newer typing features. Pyright can be used from the terminal as a
-stand-alone linter-like checker, by simply running `pyright .` (from within an activated virtual environment). But just
-like with linters, you should ideally just [include it into your editor directly](#editor-integration). We also run
-pyright automatically, as a part of [pre-commit](#pre-commit).
+`pyright`, because it has great support for many newer typing features. Specifically, this project actually uses
+`basedpyright`, which is a fork of pyright, that adds in some extra checks and features from Pylance (vscode
+extension).
+
+Pyright can be used from the terminal as a stand-alone linter-like checker, by simply running `basedpyright .` (from
+within an activated virtual environment). But just like with linters, you should ideally just [include it into your
+editor directly](#editor-integration). We also run pyright automatically, as a part of [pre-commit](#pre-commit).
 
 ## Pre-commit
 
@@ -427,7 +430,7 @@ Even though in most cases enforcing linting before each commit is what we want, 
 to commit some code which doesn't pass these checks. This can happen for example after a merge, or as a result of
 making a single purpose small commit without yet worrying about linters. In these cases, you can use the `--no-verify`
 flag when making a commit, telling git to skip all of the pre-commit hooks and commit normally. You can also only skip
-a specific hook(s), by setting `SKIP` environmental variable (e.g. `SKIP=pyright`, or
+a specific hook(s), by setting `SKIP` environmental variable (e.g. `SKIP=basedpyright`, or
 `SKIP=ruff-linter,ruff-formatter,slotscheck`), the names of the individual hooks are their ids, you can find those in
 the configuration file for pre-commit.
 
@@ -444,20 +447,16 @@ the amount of rules we have, and especially if you're not used to following many
 mistakes. Because of that, we heavily recommend that you integrate these tools into your IDE/editor directly. Most
 editors will support integration will all of these tools, so you shouldn't have any trouble doing this.
 
-If you're using neovim, I would recommend setting up LSP (Language Server Protocol), and installing Pyright, as it has
-language server support built into it. Same thing goes with `ruff`, which has an LSP implementation
+If you're using neovim, I would recommend setting up LSP (Language Server Protocol), and installing basedpyright, as it
+has language server support built into it. Same thing goes with `ruff`, which has an LSP implementation
 [`ruff-lsp`](https://github.com/astral-sh/ruff-lsp). As for slotscheck, there isn't currently any good way to integrate
 it directly, so you will need to rely on pre-commit, or run it manually. However, slotscheck violations are fairly
 rare.
 
 On vscode, you can simply install the following extensions:
 
-- [pylance (pyright)](https://marketplace.visualstudio.com/items?itemName=ms-python.vscode-pylance)
+- [BasedPyright](https://marketplace.visualstudio.com/items?itemName=detachhead.basedpyright)
 - [ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
-
-Note that with Pylance, you will also need to enable the type checking mode, by setting
-`"python.analysis.typeCheckingMode": "basic"` in `settings.json`. You can use `.vscode/settings.json` for per-project
-settings, to only enable type-checking for this project, or enable it globally in your user settings).
 
 (Similarly to neovim, there is no extension available for slotscheck, however violations are fairly rare, and it should
 be enough to have it run with pre-commit.)

--- a/changes/329.internal.md
+++ b/changes/329.internal.md
@@ -1,0 +1,3 @@
+- Change the type-checker from `pyright` to `basedpyright`
+  - BasedPyright is a fork of pyright, which provides some additional typing features and re-implements various proprietary features from the closed-source Pylance vscode extension.
+  - Overall, it is very similar to pyright with some bonus stuff on top. However, it does mean all contributors who want proper editor support for the project will need to update their editor settings and add basedpyright. The instructions on how to do this are described in the updated `CONTRIBUTING.md`.

--- a/mcproto/types/nbt.py
+++ b/mcproto/types/nbt.py
@@ -366,12 +366,13 @@ class NBTag(MCType, NBTagConvertible):
             )
 
         # Case 2 : schema is a dictionary
+        payload: list[NBTag] = []
         if isinstance(schema, dict):
             # We can unpack the dictionary and create a CompoundNBT tag
             if not isinstance(data, dict):
                 raise TypeError(f"Expected a dictionary, but found a different type ({type(data).__name__}).")
+
             # Iterate over the dictionary
-            payload: list[NBTag] = []
             for key, value in data.items():
                 # Recursive calls
                 payload.append(NBTag.from_object(value, schema[key], name=key))
@@ -384,13 +385,11 @@ class NBTag(MCType, NBTagConvertible):
         # as there are only dicts, or only lists in the schema
         if not isinstance(data, list):
             raise TypeError(f"Expected a list, but found {type(data).__name__}.")
-        payload: list[NBTag] = []
         if len(schema) == 1:
             # We have two cases here, either the schema supports an unknown number of elements of a single type ...
             children_schema = schema[0]
-            for item in data:
-                # No name in list items
-                payload.append(NBTag.from_object(item, children_schema))
+            # No name in list items
+            payload = [NBTag.from_object(item, children_schema) for item in data]
             return ListNBT(payload, name=name)
 
         # ... or the schema is a list of schemas

--- a/poetry.lock
+++ b/poetry.lock
@@ -87,6 +87,20 @@ pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
+name = "basedpyright"
+version = "1.13.3"
+description = "static type checking for Python (but based)"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "basedpyright-1.13.3-py3-none-any.whl", hash = "sha256:3162c5a5f4fc99f9d53d76cbd8e24d31ad4b28b4fb26a58ab8be6e8b634c99a7"},
+    {file = "basedpyright-1.13.3.tar.gz", hash = "sha256:728d7098250db8d18bc4b48df8f93dfd9c79d155c3c99d41256a6caa6a21232e"},
+]
+
+[package.dependencies]
+nodejs-wheel-binaries = ">=20.13.1"
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.12.3"
 description = "Screen-scraping library"
@@ -813,6 +827,22 @@ files = [
 setuptools = "*"
 
 [[package]]
+name = "nodejs-wheel-binaries"
+version = "20.15.1"
+description = "unoffical Node.js package"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "nodejs_wheel_binaries-20.15.1-py2.py3-none-macosx_10_15_x86_64.whl", hash = "sha256:a04537555f59e53021f8a2b07fa7aaac29d7793b7fae7fbf561bf9a859f4c67a"},
+    {file = "nodejs_wheel_binaries-20.15.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:b5ff04efa56a3fcd1fd09b30f5236c12bd84c10fcb222f3c0e04e1d497342b70"},
+    {file = "nodejs_wheel_binaries-20.15.1-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c3e172e3fde3c13e7509312c81700736304dbd250745d87f00e7506065f3a5"},
+    {file = "nodejs_wheel_binaries-20.15.1-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9740f7456a43cb09521a1ac93a4355dc8282c41420f2d61ff631a01f39e2aa18"},
+    {file = "nodejs_wheel_binaries-20.15.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bf5e239676efabb2fbaeff2f36d0bad8e2379f260ef44e13ef2151d037e40af3"},
+    {file = "nodejs_wheel_binaries-20.15.1-py2.py3-none-win_amd64.whl", hash = "sha256:624936171b1aa2e1cc6d1718b1caa089e943b54df16568fa2f4576d145ac279a"},
+    {file = "nodejs_wheel_binaries-20.15.1.tar.gz", hash = "sha256:b2f25b4f0e9a827ae1af8218ab13a385e279c236faf7b7c821e969bb8f6b25e8"},
+]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
@@ -943,24 +973,6 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
-
-[[package]]
-name = "pyright"
-version = "1.1.371"
-description = "Command line wrapper for pyright"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "pyright-1.1.371-py3-none-any.whl", hash = "sha256:cce52e42ff73943243e7e5e24f2a59dee81b97d99f4e3cf97370b27e8a1858cd"},
-    {file = "pyright-1.1.371.tar.gz", hash = "sha256:777b508b92dda2db476214c400ce043aad8d8f3dd0e10d284c96e79f298308b5"},
-]
-
-[package.dependencies]
-nodeenv = ">=1.6.0"
-
-[package.extras]
-all = ["twine (>=3.4.1)"]
-dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pytest"
@@ -1554,4 +1566,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4"
-content-hash = "820345752be92c8ca39ae9b1e6baaeb13bfa124d89549cd07c7389aa4183c09c"
+content-hash = "d98b6afc6e82a2c2a07dea71bbdb6ba3152db3b3886da901c94d211b9eaf9c97"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,8 +49,8 @@ pytest-httpx = { version = ">=0.23.1,<0.25.0", python = ">=3.9,<4" }
 
 [tool.poetry.group.lint.dependencies]
 ruff = ">=0.5.0"
-pyright = "^1.1.313"
 slotscheck = ">=0.16.1,<0.20.0"
+basedpyright = "^1.13.3"
 
 [tool.poetry.group.release.dependencies]
 towncrier = ">=22.12,<24.0"
@@ -79,8 +79,9 @@ optional = true
 poetry-dynamic-versioning = ">=1.4.0,<1.5"
 taskipy = "^1.10.4"
 
-[tool.pyright]
+[tool.basedpyright]
 pythonVersion = "3.8"
+typeCheckingMode = "standard"
 
 reportUntypedFunctionDecorator = "error"
 reportUntypedClassDecorator = "error"
@@ -283,7 +284,7 @@ exclude-modules = '''
 [tool.taskipy.tasks]
 precommit = "pre-commit install"
 lint = "pre-commit run --all-files"
-pyright = "pyright ."
+basedpyright = "basedpyright ."
 ruff = "ruff check --fix ."
 ruff-format = "ruff format ."
 slotscheck = "slotscheck -m mcproto"


### PR DESCRIPTION
This changes the type-checker used in the project from `pyright` to `basedpyright`.

BasedPyright is a fork of pyright, which provides some additional typing features and re-implements various proprietary features from the closed-source Pylance vscode extension.

Overall, it is very similar to pyright with some bonus stuff on top. However, it does mean all contributors who want proper editor support for the project will need to update their editor settings and add basedpyright. The instructions on how to do this are described in the updated `CONTRIBUTING.md`.