### PR TITLE
Fix deprecation logic

### DIFF
--- a/changes/330.bugfix.md
+++ b/changes/330.bugfix.md
@@ -1,0 +1,1 @@
+Fix behavior of the `mcproto.utils.deprecation` module, which was incorrectly always using a fallback version, assuming mcproto is at version 0.0.0. This then could've meant that using a deprecated feature that is past the specified deprecation (removal) version still only resulted in a deprecation warning, as opposed to a full runtime error.

--- a/mcproto/utils/deprecation.py
+++ b/mcproto/utils/deprecation.py
@@ -41,16 +41,14 @@ def deprecation_warn(
     if isinstance(removal_version, str):
         removal_version = Version(removal_version)
 
-    if isinstance(__package__, str):
-        try:
-            _project_version = importlib.metadata.version(__package__)
-        except importlib.metadata.PackageNotFoundError:
-            # v0.0.0 will never mark things as already deprecated (removal_version will always be newer)
-            project_version = Version(major=0, minor=0, patch=0)
-        else:
-            project_version = Version(_project_version)
-    else:
+    try:
+        _project_version = importlib.metadata.version("mcproto")
+    except importlib.metadata.PackageNotFoundError:
+        # v0.0.0 will never mark things as already deprecated (removal_version will always be newer)
+        warnings.warn("Failed to get mcproto project version, assuming v0.0.0", category=RuntimeWarning, stacklevel=1)
         project_version = Version(major=0, minor=0, patch=0)
+    else:
+        project_version = Version(_project_version)
 
     already_deprecated = project_version >= removal_version
 

--- a/tests/mcproto/utils/test_deprecation.py
+++ b/tests/mcproto/utils/test_deprecation.py
@@ -2,37 +2,82 @@ from __future__ import annotations
 
 import importlib.metadata
 import warnings
+from functools import wraps
 
 import pytest
 
 from mcproto.utils.deprecation import deprecated, deprecation_warn
 
 
+def _patch_project_version(monkeypatch: pytest.MonkeyPatch, version: str | None):
+    """Patch the project version reported by importlib.metadata.version.
+
+    This is used to simulate different project versions for testing purposes.
+    If ``version`` is ``None``, a :exc:`~importlib.metadata.PackageNotFoundError` will be raised
+    when trying to get the project version.
+    """
+    orig_version_func = importlib.metadata.version
+
+    @wraps(orig_version_func)
+    def patched_version_func(distribution_name: str) -> str:
+        if distribution_name == "mcproto":
+            if version is None:
+                raise importlib.metadata.PackageNotFoundError
+            return version
+        return orig_version_func(distribution_name)
+
+    monkeypatch.setattr(importlib.metadata, "version", patched_version_func)
+
+
 def test_deprecation_warn_produces_error(monkeypatch: pytest.MonkeyPatch):
     """Test deprecation_warn with older removal_version than current version produces exception."""
-    monkeypatch.setattr(importlib.metadata, "version", lambda pkg: "1.0.0")
+    _patch_project_version(monkeypatch, "1.0.0")
+
     with pytest.raises(DeprecationWarning, match="test"):
         deprecation_warn(obj_name="test", removal_version="0.9.0")
 
 
 def test_deprecation_warn_produces_warning(monkeypatch: pytest.MonkeyPatch):
     """Test deprecation_warn with newer removal_version than current version produces warning."""
-    monkeypatch.setattr(importlib.metadata, "version", lambda pkg: "1.0.0")
+    _patch_project_version(monkeypatch, "1.0.0")
+
     with warnings.catch_warnings(record=True) as w:
         deprecation_warn(obj_name="test", removal_version="1.0.1")
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert "test" in str(w[-1].message)
+
+    assert len(w) == 1
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert "test" in str(w[0].message)
+
+
+def test_deprecation_warn_unknown_version(monkeypatch: pytest.MonkeyPatch):
+    """Test deprecation_warn with unknown mcproto version.
+
+    This could occur if mcproto wasn't installed as a package. (e.g. when running directly from source,
+    like via a git submodule.)
+    """
+    _patch_project_version(monkeypatch, None)
+
+    with warnings.catch_warnings(record=True) as w:
+        deprecation_warn(obj_name="test", removal_version="1.0.0")
+
+    assert len(w) == 2
+    assert issubclass(w[0].category, RuntimeWarning)
+    assert "Failed to get mcproto project version" in str(w[0].message)
+    assert issubclass(w[1].category, DeprecationWarning)
+    assert "test" in str(w[1].message)
 
 
 def test_deprecation_decorator(monkeypatch: pytest.MonkeyPatch):
     """Check deprecated decorator with newer removal_version than current version produces warning."""
-    monkeypatch.setattr(importlib.metadata, "version", lambda pkg: "1.0.0")
+    _patch_project_version(monkeypatch, "1.0.0")
 
     @deprecated(removal_version="1.0.1")
-    def func(x):
+    def func(x: object) -> object:
         return x
 
     with warnings.catch_warnings(record=True) as w:
         assert func(5) == 5
-        assert issubclass(w[-1].category, DeprecationWarning)
-        assert "func" in str(w[-1].message)
+
+    assert len(w) == 1
+    assert issubclass(w[0].category, DeprecationWarning)
+    assert "func" in str(w[0].message)


### PR DESCRIPTION
Currently, the logic for handling deprecation is flawed, as it's using `__package__` to obtain the currently installed version of `mcproto`, however, since the deprecation.py file exists in a subpackage (`mcproto.utils`), using `importlib.metadata.version` always fails with `PackageNotFound`.

This was not caught in the unit-tests, because we blindly monkey-patched the entire `importlib.metadata.version` function to always return the expected version, regardless of the name of the package being checked.

This bug meant that the logic always assumed a fallback version of v0.0.0, which happened silently and could've meant that using a deprecated feature past it's specified deprecation version would still only result in a deprecation warning, as opposed to a full runtime exception getting raised.

This fixes the behavior by hard-coding the package-name to `mcproto` and the monkey-patching in tests now only applies to `mcproto` package specifically. Additionally, if we do get a `PackageNotFound` for `mcproto` now, instead of silently ignoring it by assuming version v0.0.0, a `RuntimeWarning` will be produced informing the user that such a fallback has occurred.

