### PR TITLE
Fix towncrier CI always failing

### DIFF
--- a/changes/347.internal.md
+++ b/changes/347.internal.md
@@ -1,0 +1,1 @@
+Fix towncrier after an update (template file isn't ignored by default, so ignore it manually)

--- a/poetry.lock
+++ b/poetry.lock
@@ -659,6 +659,24 @@ docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.link
 testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
 
 [[package]]
+name = "incremental"
+version = "24.7.2"
+description = "A small library that versions your Python projects."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "incremental-24.7.2-py3-none-any.whl", hash = "sha256:8cb2c3431530bec48ad70513931a760f446ad6c25e8333ca5d95e24b0ed7b8fe"},
+    {file = "incremental-24.7.2.tar.gz", hash = "sha256:fb4f1d47ee60efe87d4f6f0ebb5f70b9760db2b2574c59c8e8912be4ebd464c9"},
+]
+
+[package.dependencies]
+setuptools = ">=61.0"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[package.extras]
+scripts = ["click (>=6.0)"]
+
+[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1461,24 +1479,24 @@ files = [
 
 [[package]]
 name = "towncrier"
-version = "24.7.1"
+version = "23.11.0"
 description = "Building newsfiles for your project."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "towncrier-24.7.1-py3-none-any.whl", hash = "sha256:685e2a94335b5dc47537b4d3b449a25b18571ea85b07dcf6e8df31ba40f692dd"},
-    {file = "towncrier-24.7.1.tar.gz", hash = "sha256:57a057faedabcadf1a62f6f9bad726ae566c1f31a411338ddb8316993f583b3d"},
+    {file = "towncrier-23.11.0-py3-none-any.whl", hash = "sha256:2e519ca619426d189e3c98c99558fe8be50c9ced13ea1fc20a4a353a95d2ded7"},
+    {file = "towncrier-23.11.0.tar.gz", hash = "sha256:13937c247e3f8ae20ac44d895cf5f96a60ad46cfdcc1671759530d7837d9ee5d"},
 ]
 
 [package.dependencies]
 click = "*"
-importlib-metadata = {version = ">=4.6", markers = "python_version < \"3.10\""}
 importlib-resources = {version = ">=5", markers = "python_version < \"3.10\""}
+incremental = "*"
 jinja2 = "*"
 tomli = {version = "*", markers = "python_version < \"3.11\""}
 
 [package.extras]
-dev = ["furo (>=2024.05.06)", "nox", "packaging", "sphinx (>=5)", "twisted"]
+dev = ["furo", "packaging", "sphinx (>=5)", "twisted"]
 
 [[package]]
 name = "typing-extensions"
@@ -1546,4 +1564,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4"
-content-hash = "9acc37e791eb2852402a9b68aea108559fbdc4662056101d978e7665fa4dfe8a"
+content-hash = "4f4a1570b23a9b30266e893b2d9626e81e2e7c3c0307f072ffc110093d884af2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ slotscheck = ">=0.16.1,<0.20.0"
 basedpyright = "^1.13.3"
 
 [tool.poetry.group.release.dependencies]
-towncrier = ">=22.12,<25.0"
+towncrier = "==23.11" # temporary pin, as 24.7 is incompatible with sphinxcontrib-towncrier
 
 [tool.poetry.group.release-ci]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,7 @@ source = ["mcproto"]
 package = "mcproto"
 directory = "changes"
 template = "changes/.template.rst"
+ignore = [".template.rst"]
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/py-mine/mcproto/issues/{issue})"
 orphan_prefix = "+" # Use '+' instead of number for fragments not connected to any PR


### PR DESCRIPTION
After an automatic update of the towncrier dependency in #345, the CI started to fail in 2 places:
- The sphinx documentation build

  The `sphinxcontrib-towncrier` extension isn't compatible with this latest version and fails due to a change in the towncrier internal API code, which this extension uses. See: https://github.com/sphinx-contrib/sphinxcontrib-towncrier/issues/92. At the moment, the only way to fix this is to revert towncrier to an older version.

- The PR changelog fragment check

  It seems that the new towncrier version no longer automatically ignores the template file. Since we place this file in the fragments directory, `towncrier check` always fails with an error that this file isn't correctly named. The automatic update succeeded because these updates are exempt from changelog fragment presence check, so it got into main unnoticed.
  
  This PR fixes that by adding the template file to ignored files. (Even though the towncrier dependency will be reverted, the ignore can remain, as it at least prevents it from breaking once we do update)