### PR TITLE
Add automatic labeling for stale issues/PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,34 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 */4 * * *"
+  workflow_dispatch:
+
+jobs:
+  stale:
+    # Don't run in forks, they probably don't have the same labels set up
+    if: github.repository == 'py-mine/mcproto'
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - uses: actions/stale@v5
+        with:
+          repo-token: ${{ steps.generate_token.outputs.token }}
+          stale-issue-label: "s: stale"
+          stale-pr-label: "s: stale"
+          exempt-issue-labels: "s: deferred,s: stalled"
+          exempt-pr-labels: "s: deferred,s: stalled"
+          days-before-stale: 60
+          days-before-close: -1

--- a/changes/395.internal.md
+++ b/changes/395.internal.md
@@ -1,0 +1,1 @@
+Add CI workflow for marking inactive issues (>60 days) with the stale label


### PR DESCRIPTION
This adds a CI workflow that detects any open PRs or issues that didn't have any activity for longer than 60 days, adding the `s: stale` label to them.