### PR TITLE
Use PEP-440 compatible version comparisons

### DIFF
--- a/changes/427.bugfix.md
+++ b/changes/427.bugfix.md
@@ -1,0 +1,1 @@
+Fix version comparisons in deprecated functions for PEP440, non-semver compatible versions

--- a/mcproto/utils/deprecation.py
+++ b/mcproto/utils/deprecation.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import TypeVar
 
-from semantic_version import Version
+from packaging.version import Version
 from typing_extensions import ParamSpec, Protocol
 
 __all__ = ["deprecated", "deprecation_warn"]
@@ -46,7 +46,7 @@ def deprecation_warn(
     except importlib.metadata.PackageNotFoundError:
         # v0.0.0 will never mark things as already deprecated (removal_version will always be newer)
         warnings.warn("Failed to get mcproto project version, assuming v0.0.0", category=RuntimeWarning, stacklevel=1)
-        project_version = Version(major=0, minor=0, patch=0)
+        project_version = Version("0.0.0")
     else:
         project_version = Version(_project_version)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1169,21 +1169,6 @@ files = [
 ]
 
 [[package]]
-name = "semantic-version"
-version = "2.10.0"
-description = "A library implementing the 'SemVer' scheme."
-optional = false
-python-versions = ">=2.7"
-files = [
-    {file = "semantic_version-2.10.0-py2.py3-none-any.whl", hash = "sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177"},
-    {file = "semantic_version-2.10.0.tar.gz", hash = "sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c"},
-]
-
-[package.extras]
-dev = ["Django (>=1.11)", "check-manifest", "colorama (<=0.4.1)", "coverage", "flake8", "nose2", "readme-renderer (<25.0)", "tox", "wheel", "zest.releaser[recommended]"]
-doc = ["Sphinx", "sphinx-rtd-theme"]
-
-[[package]]
 name = "setuptools"
 version = "70.0.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1597,4 +1582,4 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4"
-content-hash = "2f9aa793e213141e68422e49e76103da9b827dbac75696670cad47f7b5c27ea7"
+content-hash = "2655dd18deb6f4ae1e0c3910d45801a43d08260136e44178e9ac5b974001e058"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ packages = [{ include = "mcproto" }]
 python = ">=3.9,<4"
 asyncio-dgram = "^2.1.2"
 typing-extensions = "^4.4.0"
-semantic-version = "^2.10.0"
 httpx = "^0.24.1"
 cryptography = ">=41.0.3,<44.0.0"
 attrs = ">=23.2,<25.0"
+packaging = "^24.2"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = ">=2.18.1,<5.0.0"


### PR DESCRIPTION
Currently, we we're using the [`semantic-version`](https://pypi.org/project/semantic-version/) library, to construct it's custom `Version` objects, which have comparison support, however, this could easily lead to issues, as python packaging doesn't follow the semver naming spec exactly, instead, it follows the spec from [PEP-440](https://peps.python.org/pep-0440/).

This means certain things, such as alpha releases, use version tags like `1.1.0a1`, instead of the semver alternative (`1.1.0-alpha.1`). Using these incompatible version strings with the `semantic_version.Version` class would lead to a `ValueError` getting raised during initialization. This would cause all deprecated objects to be unusable on these semver-incompatible mcproto versions, as the decorator where this check happens would end with this `ValueError`.

This fixes the issue by moving to [`packaging.version.Version`](https://packaging.pypa.io/en/stable/version.html#packaging.version.Version), which was designed specifically for the PEP-440 version naming standard.